### PR TITLE
Set LUA_PATH envvar for fcitx5-lua

### DIFF
--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -499,6 +499,18 @@ Java_org_fcitx_fcitx5_android_core_Fcitx_startupFcitx(JNIEnv *env, jclass clazz,
     std::string usr_share = fcitx::stringutils::joinPath(*appData_, "usr", "share");
     std::string locale_dir = fcitx::stringutils::joinPath(usr_share, "locale");
     std::string libime_data = fcitx::stringutils::joinPath(usr_share, "libime");
+    std::string lua_path = fcitx::stringutils::concat(
+            fcitx::stringutils::joinPath(data_home, "lua", "?.lua"), ";",
+            fcitx::stringutils::joinPath(data_home, "lua", "?", "init.lua"), ";",
+            fcitx::stringutils::joinPath(usr_share, "lua", "5.4", "?.lua"), ";",
+            fcitx::stringutils::joinPath(usr_share, "lua", "5.4", "?", "init.lua"), ";",
+            ";" // double semicolon, for default path defined in luaconf.h
+            );
+    std::string lua_cpath = fcitx::stringutils::concat(
+            fcitx::stringutils::joinPath(data_home, "lua", "?.so"), ";",
+            fcitx::stringutils::joinPath(usr_share, "lua", "5.4", "?.so"), ";",
+            ";"
+            );
 
     // for fcitx default profile [DefaultInputMethod]
     setenv("LANG", lang_.c_str(), 1);
@@ -512,6 +524,8 @@ Java_org_fcitx_fcitx5_android_core_Fcitx_startupFcitx(JNIEnv *env, jclass clazz,
     setenv("FCITX_DATA_HOME", data_home.c_str(), 1);
     setenv("FCITX_ADDON_DIRS", appLib_, 1);
     setenv("LIBIME_MODEL_DIRS", libime_data.c_str(), 1);
+    setenv("LUA_PATH", lua_path.c_str(), 1);
+    setenv("LUA_CPATH", lua_cpath.c_str(), 1);
 
     const char *locale_dir_char = locale_dir.c_str();
     fcitx::registerDomain("fcitx5", locale_dir_char);


### PR DESCRIPTION
设置好`LUA_PATH`和`LUA_CPATH`后就可以引入模块了  
- `$FCITX_DATA_HOME/lua`，为非root用户提供模块放置的位置
- `$XDG_DATA_DIRS/lua/5.4`，和电脑上的lua位置是一样的，为那种反编译再重新打包来集成资源的人提供（放置在assets/usr/share/lua/5.4）
- 保留了预置的`/usr/local/share/lua/5.4`，但是对非root用户来说显然没有任何意义

当然这是我自己定的，或者你看放置在哪里好一点

下面两例测试通过
## 例子一：
1. `json_example.lua`，文件内容如下：
```lua
local json = require ("dkjson")

local tbl = {
  animals = { "dog", "cat", "aardvark" },
  instruments = { "violin", "trombone", "theremin" },
  bugs = json.null,
  trees = nil
}

function output()
  return {
    json.encode (tbl, { indent = true })
  }
end

ime.register_command("bm", "output", "", "none")
```
2. `dkjson.lua`，[在此下载](http://dkolf.de/src/dkjson-lua.fsl/raw/dkjson.lua?name=6c6486a4a589ed9ae70654a2821e956650299228)  
3. 编译并安装fcitx5，`dkjson.lua`放置在`存储/Android/data/org.fcitx.fcitx5.android/files/data/lua/`，`json_example.json`放置在`存储/Android/data/org.fcitx.fcitx5.android/files/data/lua/imeapi/extensions/`，重启fcitx5 
4. 进入 QuickPhrase 模式并输入 `bm`，能够正常输出json。在以前日志会提示找不到模块

## 例子二：
1. 解包一个fcitx5的安装包
2. 上述`dkjson.lua`，放置在`app/src/main/assets/usr/share/lua/5.4/`，~并修改那个清单json文件~（gradle 构建时会自动生成）
3. 签名，安装这个改过的包
4. `json_example.lua`还是放在上述位置，重启配置
5. 进入 QuickPhrase 模式并输入 `bm`