### PR TITLE
Support per-app language preferences on Android 13+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:roundIcon="@mipmap/app_icon_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.FcitxAppTheme"
-        tools:targetApi="31">
+        android:localeConfig="@xml/locales_config"
+    tools:targetApi="31">
         <activity
             android:name=".ui.setup.SetupActivity"
             android:exported="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.FcitxAppTheme"
         android:localeConfig="@xml/locales_config"
-    tools:targetApi="31">
+        tools:targetApi="33">
         <activity
             android:name=".ui.setup.SetupActivity"
             android:exported="false"

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="ru"/>
+    <locale android:name="ko"/>
+    <locale android:name="ja"/>
+    <locale android:name="zh-CN"/>
+    <locale android:name="zh-TW"/>
+</locale-config>


### PR DESCRIPTION
Allow selecting interface language in Android settings, supported in Android 13 only
https://developer.android.com/guide/topics/resources/app-languages
![screenshot](https://user-images.githubusercontent.com/23287823/201588833-81fc17e4-45ad-4a63-9449-f233de735509.jpg)
