### PR TITLE
Set hash style to gnu and disable build id

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -7,7 +7,7 @@ set(ANDROID_STL c++_shared)
 set(CMAKE_CXX_STANDARD 17)
 
 # For reproducible build
-add_link_options(-Wl,--hash-style=gnu,--build-id=none)
+add_link_options("LINKER:--hash-style=gnu,--build-id=none")
 
 set(CMAKE_INSTALL_PREFIX /usr)
 set(FCITX_INSTALL_PKGDATADIR /usr/share/fcitx5)

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -6,6 +6,9 @@ set(ANDROID_STL c++_shared)
 
 set(CMAKE_CXX_STANDARD 17)
 
+# For reproducible build
+add_link_options(-Wl,--hash-style=gnu,--build-id=none)
+
 set(CMAKE_INSTALL_PREFIX /usr)
 set(FCITX_INSTALL_PKGDATADIR /usr/share/fcitx5)
 set(FCITX_INSTALL_LOCALEDIR /usr/share/locale)


### PR DESCRIPTION
... for reproducible build.

For some reasons the default hash style is both on debian but gnu on arch. Build id is different when the ndk path is different.

This should make most .so file reproducible on F-Droid's buildserver.