### PR TITLE
Refactor event state machine

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ExpandButtonStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ExpandButtonStateMachine.kt
@@ -1,5 +1,6 @@
 package org.fcitx.fcitx5.android.input.bar
 
+import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.BooleanKey.CandidatesEmpty
 import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.ClickToAttachWindow
 import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.ClickToDetachWindow
 import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.Hidden
@@ -22,15 +23,15 @@ object ExpandButtonStateMachine {
     enum class TransitionEvent(val builder: TransitionBuildBlock<State, BooleanKey>) :
         EventStateMachine.TransitionEvent<State, BooleanKey> by BuildTransitionEvent(builder) {
         ExpandedCandidatesUpdated({
-            from(Hidden) transitTo ClickToAttachWindow on { it(BooleanKey.CandidatesEmpty) == false }
-            from(ClickToAttachWindow) transitTo Hidden on { it(BooleanKey.CandidatesEmpty) == true }
+            from(Hidden) transitTo ClickToAttachWindow on (CandidatesEmpty to false)
+            from(ClickToAttachWindow) transitTo Hidden on (CandidatesEmpty to true)
         }),
         ExpandedCandidatesAttached({
             from(ClickToAttachWindow) transitTo ClickToDetachWindow
         }),
         ExpandedCandidatesDetached({
-            from(ClickToDetachWindow) transitTo Hidden on { it(BooleanKey.CandidatesEmpty) == true }
-            from(ClickToDetachWindow) transitTo ClickToAttachWindow on { it(BooleanKey.CandidatesEmpty) == true }
+            from(ClickToDetachWindow) transitTo Hidden on (CandidatesEmpty to true)
+            from(ClickToDetachWindow) transitTo ClickToAttachWindow on (CandidatesEmpty to true)
         });
     }
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ExpandButtonStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ExpandButtonStateMachine.kt
@@ -31,7 +31,7 @@ object ExpandButtonStateMachine {
         }),
         ExpandedCandidatesDetached({
             from(ClickToDetachWindow) transitTo Hidden on (CandidatesEmpty to true)
-            from(ClickToDetachWindow) transitTo ClickToAttachWindow on (CandidatesEmpty to true)
+            from(ClickToDetachWindow) transitTo ClickToAttachWindow on (CandidatesEmpty to false)
         });
     }
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ExpandButtonStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ExpandButtonStateMachine.kt
@@ -1,9 +1,11 @@
 package org.fcitx.fcitx5.android.input.bar
 
-import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.*
-import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.TransitionEvent.*
+import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.ClickToAttachWindow
+import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.ClickToDetachWindow
+import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.Hidden
+import org.fcitx.fcitx5.android.utils.BuildTransitionEvent
 import org.fcitx.fcitx5.android.utils.EventStateMachine
-import org.fcitx.fcitx5.android.utils.eventStateMachine
+import org.fcitx.fcitx5.android.utils.TransitionBuildBlock
 
 
 object ExpandButtonStateMachine {
@@ -13,23 +15,28 @@ object ExpandButtonStateMachine {
         Hidden
     }
 
-    enum class TransitionEvent {
-        ExpandedCandidatesUpdatedEmpty,
-        ExpandedCandidatesUpdatedNonEmpty,
-        ExpandedCandidatesAttached,
-        ExpandedCandidatesDetachedWithCandidatesEmpty,
-        ExpandedCandidatesDetachedWithCandidatesNonEmpty,
+    enum class BooleanKey : EventStateMachine.BooleanStateKey {
+        CandidatesEmpty
     }
 
-    fun new(block: (State) -> Unit): EventStateMachine<State, TransitionEvent> =
-        eventStateMachine(
-            Hidden
-        ) {
-            from(Hidden) transitTo ClickToAttachWindow on ExpandedCandidatesUpdatedNonEmpty
-            from(ClickToAttachWindow) transitTo Hidden on ExpandedCandidatesUpdatedEmpty
-            from(ClickToAttachWindow) transitTo ClickToDetachWindow on ExpandedCandidatesAttached
-            from(ClickToDetachWindow) transitTo ClickToAttachWindow on ExpandedCandidatesDetachedWithCandidatesNonEmpty
-            from(ClickToDetachWindow) transitTo Hidden on ExpandedCandidatesDetachedWithCandidatesEmpty
-            onNewState(block)
+    enum class TransitionEvent(val builder: TransitionBuildBlock<State, BooleanKey>) :
+        EventStateMachine.TransitionEvent<State, BooleanKey> by BuildTransitionEvent(builder) {
+        ExpandedCandidatesUpdated({
+            from(Hidden) transitTo ClickToAttachWindow on { it(BooleanKey.CandidatesEmpty) == false }
+            from(ClickToAttachWindow) transitTo Hidden on { it(BooleanKey.CandidatesEmpty) == true }
+        }),
+        ExpandedCandidatesAttached({
+            from(ClickToAttachWindow) transitTo ClickToDetachWindow
+        }),
+        ExpandedCandidatesDetached({
+            from(ClickToDetachWindow) transitTo Hidden on { it(BooleanKey.CandidatesEmpty) == true }
+            from(ClickToDetachWindow) transitTo ClickToAttachWindow on { it(BooleanKey.CandidatesEmpty) == true }
+        });
+    }
+
+    fun new(block: (State) -> Unit) =
+        EventStateMachine<State, TransitionEvent, BooleanKey>(Hidden).apply {
+            onNewStateListener = block
         }
 }
+

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/IdleUiStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/IdleUiStateMachine.kt
@@ -1,49 +1,69 @@
 package org.fcitx.fcitx5.android.input.bar
 
-import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.State.*
-import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.*
+import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.BooleanKey.ClipboardEmpty
+import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.State.Clipboard
+import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.State.ClipboardTimedOut
+import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.State.Empty
+import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.State.Toolbar
+import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.State.ToolbarWithClip
+import org.fcitx.fcitx5.android.utils.BuildTransitionEvent
 import org.fcitx.fcitx5.android.utils.EventStateMachine
-import org.fcitx.fcitx5.android.utils.eventStateMachine
+import org.fcitx.fcitx5.android.utils.TransitionBuildBlock
 
 object IdleUiStateMachine {
     enum class State {
         Clipboard, Toolbar, Empty, ToolbarWithClip, ClipboardTimedOut
     }
 
-    enum class TransitionEvent {
-        Timeout,
-        Pasted,
-        MenuButtonClicked,
-        ClipboardUpdatedEmpty,
-        ClipboardUpdatedNonEmpty,
-        KawaiiBarShown,
+    enum class BooleanKey : EventStateMachine.BooleanStateKey {
+        ClipboardEmpty
     }
 
-    fun new(
-        toolbarByDefault: Boolean,
-        old: EventStateMachine<State, TransitionEvent>? = null,
-        block: ((State) -> Unit)? = null
-    ): EventStateMachine<State, TransitionEvent> {
-        val initialState = if (toolbarByDefault) Toolbar else Empty
-        return eventStateMachine(old?.currentState ?: initialState) {
-            from(Toolbar) transitTo Clipboard on ClipboardUpdatedNonEmpty
-            from(Toolbar) transitTo Empty on MenuButtonClicked
-            from(ToolbarWithClip) transitTo Toolbar on Timeout
-            from(ToolbarWithClip) transitTo Toolbar on ClipboardUpdatedEmpty
-            from(ToolbarWithClip) transitTo Clipboard on MenuButtonClicked
-            from(ToolbarWithClip) transitTo Clipboard on ClipboardUpdatedNonEmpty
-            from(Clipboard) transitTo ToolbarWithClip on MenuButtonClicked
-            from(Clipboard) transitTo ClipboardTimedOut on Timeout
-            from(Clipboard) transitTo initialState on Pasted
-            from(Clipboard) transitTo initialState on ClipboardUpdatedEmpty
-            from(ClipboardTimedOut) transitTo Toolbar on MenuButtonClicked
-            from(ClipboardTimedOut) transitTo initialState on KawaiiBarShown
-            from(ClipboardTimedOut) transitTo initialState on Pasted
-            from(ClipboardTimedOut) transitTo initialState on ClipboardUpdatedEmpty
-            from(ClipboardTimedOut) transitTo Clipboard on ClipboardUpdatedNonEmpty
-            from(Empty) transitTo Toolbar on MenuButtonClicked
-            from(Empty) transitTo Clipboard on ClipboardUpdatedNonEmpty
-            onNewState(old?.onNewStateListener ?: block ?: throw IllegalArgumentException())
-        }
+    enum class TransitionEvent(val builder: TransitionBuildBlock<State, BooleanKey>) :
+        EventStateMachine.TransitionEvent<State, BooleanKey> by BuildTransitionEvent(builder) {
+        Timeout({
+            from(ToolbarWithClip) transitTo Toolbar
+            from(Clipboard) transitTo ClipboardTimedOut
+        }),
+        Pasted({
+            accept { initial, current, _ ->
+                when (current) {
+                    Clipboard -> initial
+                    ClipboardTimedOut -> initial
+                    else -> current
+                }
+            }
+        }),
+        MenuButtonClicked({
+            from(Toolbar) transitTo Empty
+            from(ToolbarWithClip) transitTo Clipboard
+            from(Clipboard) transitTo ToolbarWithClip
+            from(ClipboardTimedOut) transitTo Toolbar
+            from(Empty) transitTo Toolbar
+        }),
+        ClipboardUpdated({
+            accept { initial, current, bool ->
+                val clipboardEmpty = bool(ClipboardEmpty) == true
+                when (current) {
+                    ToolbarWithClip -> if (clipboardEmpty) Toolbar else Clipboard
+                    Clipboard -> if (clipboardEmpty) initial else current
+                    ClipboardTimedOut -> if (clipboardEmpty) initial else Clipboard
+                    Toolbar -> if (!clipboardEmpty) Clipboard else current
+                    Empty -> if (!clipboardEmpty) Clipboard else current
+                }
+            }
+        }),
+        KawaiiBarShown({
+            accept { initial, current, _ ->
+                if (current == ClipboardTimedOut) initial
+                else current
+            }
+        })
     }
+
+    fun new(toolbarByDefault: Boolean, block: (State) -> Unit) =
+        EventStateMachine<State, TransitionEvent, BooleanKey>(if (toolbarByDefault) Toolbar else Empty).apply {
+            onNewStateListener = block
+        }
+
 }

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarComponent.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarComponent.kt
@@ -30,10 +30,11 @@ import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.Pas
 import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.Timeout
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.CandidateEmpty
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.CapFlagsPassword
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.PreeditEmpty
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.CandidatesUpdated
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.CapFlagsUpdated
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.ExtendedWindowAttached
-import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.PreeditUpdatedNonEmpty
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.PreeditUpdated
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.WindowDetached
 import org.fcitx.fcitx5.android.input.broadcast.InputBroadcastReceiver
 import org.fcitx.fcitx5.android.input.candidates.HorizontalCandidateComponent
@@ -309,8 +310,10 @@ class KawaiiBarComponent : UniqueViewComponent<KawaiiBarComponent, FrameLayout>(
     }
 
     override fun onPreeditUpdate(data: FcitxEvent.PreeditEvent.Data) {
-        if (!(data.preedit.isEmpty() && data.clientPreedit.isEmpty()))
-            barStateMachine.push(PreeditUpdatedNonEmpty)
+        barStateMachine.push(
+            PreeditUpdated,
+            PreeditEmpty to (data.preedit.isEmpty() && data.clientPreedit.isEmpty())
+        )
     }
 
     override fun onCandidateUpdate(data: Array<String>) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarComponent.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarComponent.kt
@@ -22,21 +22,19 @@ import org.fcitx.fcitx5.android.data.theme.ThemeManager
 import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.ClickToAttachWindow
 import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.ClickToDetachWindow
 import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.State.Hidden
-import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.ClipboardUpdatedEmpty
-import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.ClipboardUpdatedNonEmpty
+import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.BooleanKey.ClipboardEmpty
+import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.ClipboardUpdated
 import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.KawaiiBarShown
 import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.MenuButtonClicked
 import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.Pasted
 import org.fcitx.fcitx5.android.input.bar.IdleUiStateMachine.TransitionEvent.Timeout
-import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.CandidateUpdateNonEmpty
-import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.CapFlagsUpdatedNoPassword
-import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.CapFlagsUpdatedPassword
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.CandidateEmpty
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.CapFlagsPassword
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.CandidatesUpdated
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.CapFlagsUpdated
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.ExtendedWindowAttached
-import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.PreeditUpdatedEmpty
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.PreeditUpdatedNonEmpty
-import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.WindowDetachedWithCandidatesNonEmpty
-import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.WindowDetachedWithCapFlagsNoPassword
-import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.WindowDetachedWithCapFlagsPassword
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.WindowDetached
 import org.fcitx.fcitx5.android.input.broadcast.InputBroadcastReceiver
 import org.fcitx.fcitx5.android.input.candidates.HorizontalCandidateComponent
 import org.fcitx.fcitx5.android.input.candidates.expanded.ExpandedCandidateStyle
@@ -55,7 +53,6 @@ import org.fcitx.fcitx5.android.input.status.StatusAreaWindow
 import org.fcitx.fcitx5.android.input.wm.InputWindow
 import org.fcitx.fcitx5.android.input.wm.InputWindowManager
 import org.fcitx.fcitx5.android.utils.AppUtil
-import org.fcitx.fcitx5.android.utils.isInPasswordMode
 import org.mechdancer.dependency.DynamicScope
 import org.mechdancer.dependency.manager.must
 import splitties.bitflags.hasFlag
@@ -89,10 +86,10 @@ class KawaiiBarComponent : UniqueViewComponent<KawaiiBarComponent, FrameLayout>(
             if (!clipboardSuggestion.getValue()) return@OnClipboardUpdateListener
             service.lifecycleScope.launch {
                 if (it.text.isEmpty()) {
-                    idleUiStateMachine.push(ClipboardUpdatedEmpty)
+                    idleUiStateMachine.push(ClipboardUpdated, ClipboardEmpty to true)
                 } else {
                     idleUi.setClipboardItemText(it.text.take(42))
-                    idleUiStateMachine.push(ClipboardUpdatedNonEmpty)
+                    idleUiStateMachine.push(ClipboardUpdated, ClipboardEmpty to false)
                     launchClipboardTimeoutJob()
                 }
             }
@@ -101,7 +98,7 @@ class KawaiiBarComponent : UniqueViewComponent<KawaiiBarComponent, FrameLayout>(
     private val onClipboardSuggestionUpdateListener =
         ManagedPreference.OnChangeListener<Boolean> { _, it ->
             if (!it) {
-                idleUiStateMachine.push(ClipboardUpdatedEmpty)
+                idleUiStateMachine.push(ClipboardUpdated, ClipboardEmpty to true)
                 clipboardTimeoutJob?.cancel()
                 clipboardTimeoutJob = null
             }
@@ -122,7 +119,9 @@ class KawaiiBarComponent : UniqueViewComponent<KawaiiBarComponent, FrameLayout>(
 
     private val onExpandToolbarByDefaultUpdateListener =
         ManagedPreference.OnChangeListener<Boolean> { _, it ->
-            idleUiStateMachine = IdleUiStateMachine.new(it, idleUiStateMachine)
+            idleUiStateMachine = IdleUiStateMachine.new(it) {
+                idleUi.switchUiByState(it)
+            }
         }
 
     private val popupActionListener by lazy {
@@ -305,26 +304,17 @@ class KawaiiBarComponent : UniqueViewComponent<KawaiiBarComponent, FrameLayout>(
             idleUi.privateMode(info.imeOptions.hasFlag(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING))
         }
         idleUiStateMachine.push(KawaiiBarShown)
-        barStateMachine.push(
-            if (capFlags.has(CapabilityFlag.Password))
-                CapFlagsUpdatedPassword
-            else
-                CapFlagsUpdatedNoPassword
-        )
+        barStateMachine.setBooleanState(CapFlagsPassword, capFlags.has(CapabilityFlag.Password))
+        barStateMachine.push(CapFlagsUpdated)
     }
 
     override fun onPreeditUpdate(data: FcitxEvent.PreeditEvent.Data) {
-        barStateMachine.push(
-            if (data.preedit.isEmpty() && data.clientPreedit.isEmpty())
-                PreeditUpdatedEmpty
-            else
-                PreeditUpdatedNonEmpty
-        )
+        if (!(data.preedit.isEmpty() && data.clientPreedit.isEmpty()))
+            barStateMachine.push(PreeditUpdatedNonEmpty)
     }
 
     override fun onCandidateUpdate(data: Array<String>) {
-        if (data.isNotEmpty())
-            barStateMachine.push(CandidateUpdateNonEmpty)
+        barStateMachine.push(CandidatesUpdated, CandidateEmpty to data.isEmpty())
     }
 
     override fun onWindowAttached(window: InputWindow) {
@@ -344,15 +334,7 @@ class KawaiiBarComponent : UniqueViewComponent<KawaiiBarComponent, FrameLayout>(
     }
 
     override fun onWindowDetached(window: InputWindow) {
-        barStateMachine.push(
-            if (horizontalCandidate.adapter.candidates.isEmpty())
-                if (service.isInPasswordMode)
-                    WindowDetachedWithCapFlagsPassword
-                else
-                    WindowDetachedWithCapFlagsNoPassword
-            else
-                WindowDetachedWithCandidatesNonEmpty
-        )
+        barStateMachine.push(WindowDetached)
     }
 
 }

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarStateMachine.kt
@@ -1,5 +1,7 @@
 package org.fcitx.fcitx5.android.input.bar
 
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.CandidateEmpty
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.CapFlagsPassword
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.State.Candidate
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.State.Idle
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.State.NumberRow
@@ -20,11 +22,11 @@ object KawaiiBarStateMachine {
     enum class TransitionEvent(val builder: TransitionBuildBlock<State, BooleanKey>) :
         EventStateMachine.TransitionEvent<State, BooleanKey> by BuildTransitionEvent(builder) {
         PreeditUpdatedNonEmpty({
-            from(Candidate) transitTo Idle on { it(BooleanKey.CandidateEmpty) == true }
-            from(Idle) transitTo Candidate on { it(BooleanKey.CandidateEmpty) == false }
+            from(Candidate) transitTo Idle on (CandidateEmpty to true)
+            from(Idle) transitTo Candidate on (CandidateEmpty to false)
         }),
         CandidatesUpdated({
-            from(Idle) transitTo Candidate on { it(BooleanKey.CandidateEmpty) == false }
+            from(Idle) transitTo Candidate on (CandidateEmpty to false)
         }),
         ExtendedWindowAttached({
             from(Idle) transitTo Title
@@ -32,21 +34,17 @@ object KawaiiBarStateMachine {
             from(NumberRow) transitTo Title
         }),
         CapFlagsUpdated({
-            from(Idle) transitTo NumberRow on { it(BooleanKey.CapFlagsPassword) == true }
-            from(NumberRow) transitTo Idle on { it(BooleanKey.CapFlagsPassword) == false }
+            from(Idle) transitTo NumberRow on (CapFlagsPassword to true)
+            from(NumberRow) transitTo Idle on (CapFlagsPassword to false)
         }),
         WindowDetached({
             // candidate state has higher priority so here it goes first
-            from(Title) transitTo Candidate on {
-                it(
-                    BooleanKey.CandidateEmpty
-                ) == false
-            }
-            from(Title) transitTo Idle on { it(BooleanKey.CapFlagsPassword) == false }
-            from(Title) transitTo NumberRow on { it(BooleanKey.CapFlagsPassword) == true }
+            from(Title) transitTo Candidate on (CandidateEmpty to false)
+            from(Title) transitTo Idle on (CapFlagsPassword to false)
+            from(Title) transitTo NumberRow on (CapFlagsPassword to true)
         }),
         KeyboardSwitchedOutNumber({
-            from(Idle) transitTo NumberRow on { it(BooleanKey.CapFlagsPassword) == true }
+            from(Idle) transitTo NumberRow on (CapFlagsPassword to true)
         }),
         KeyboardSwitchedToNumber({
             from(NumberRow) transitTo Idle

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarStateMachine.kt
@@ -2,6 +2,7 @@ package org.fcitx.fcitx5.android.input.bar
 
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.CandidateEmpty
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.CapFlagsPassword
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.BooleanKey.PreeditEmpty
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.State.Candidate
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.State.Idle
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.State.NumberRow
@@ -16,14 +17,14 @@ object KawaiiBarStateMachine {
     }
 
     enum class BooleanKey : EventStateMachine.BooleanStateKey {
-        CandidateEmpty, CapFlagsPassword
+        PreeditEmpty, CandidateEmpty, CapFlagsPassword
     }
 
     enum class TransitionEvent(val builder: TransitionBuildBlock<State, BooleanKey>) :
         EventStateMachine.TransitionEvent<State, BooleanKey> by BuildTransitionEvent(builder) {
-        PreeditUpdatedNonEmpty({
-            from(Candidate) transitTo Idle on (CandidateEmpty to true)
-            from(Idle) transitTo Candidate on (CandidateEmpty to false)
+        PreeditUpdated({
+            from(Candidate) transitTo Idle on (PreeditEmpty to true)
+            from(Idle) transitTo Candidate on (PreeditEmpty to false)
         }),
         CandidatesUpdated({
             from(Idle) transitTo Candidate on (CandidateEmpty to false)

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/candidates/HorizontalCandidateComponent.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/candidates/HorizontalCandidateComponent.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.fcitx.fcitx5.android.R
 import org.fcitx.fcitx5.android.data.prefs.AppPrefs
-import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.TransitionEvent.ExpandedCandidatesUpdatedEmpty
-import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.TransitionEvent.ExpandedCandidatesUpdatedNonEmpty
+import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.BooleanKey.CandidatesEmpty
+import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.TransitionEvent.ExpandedCandidatesUpdated
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarComponent
 import org.fcitx.fcitx5.android.input.broadcast.InputBroadcastReceiver
 import org.fcitx.fcitx5.android.input.candidates.expanded.decoration.FlexboxVerticalDecoration
@@ -63,10 +63,8 @@ class HorizontalCandidateComponent :
                     super.onLayoutCompleted(state)
                     refreshExpanded()
                     bar.expandButtonStateMachine.push(
-                        if (adapter!!.itemCount - childCount > 0)
-                            ExpandedCandidatesUpdatedNonEmpty
-                        else
-                            ExpandedCandidatesUpdatedEmpty
+                        ExpandedCandidatesUpdated,
+                        CandidatesEmpty to (adapter!!.itemCount - childCount <= 0)
                     )
                 }
             }

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/candidates/expanded/window/BaseExpandedCandidateWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/candidates/expanded/window/BaseExpandedCandidateWindow.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.fcitx.fcitx5.android.core.FcitxEvent
 import org.fcitx.fcitx5.android.data.prefs.AppPrefs
-import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.TransitionEvent.*
+import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.BooleanKey.CandidatesEmpty
+import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.TransitionEvent.ExpandedCandidatesAttached
+import org.fcitx.fcitx5.android.input.bar.ExpandButtonStateMachine.TransitionEvent.ExpandedCandidatesDetached
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarComponent
 import org.fcitx.fcitx5.android.input.broadcast.InputBroadcastReceiver
 import org.fcitx.fcitx5.android.input.candidates.CandidateViewBuilder
@@ -88,10 +90,8 @@ abstract class BaseExpandedCandidateWindow<T : BaseExpandedCandidateWindow<T>> :
 
     override fun onDetached() {
         bar.expandButtonStateMachine.push(
-            if (adapter.candidates.size > adapter.offset)
-                ExpandedCandidatesDetachedWithCandidatesNonEmpty
-            else
-                ExpandedCandidatesDetachedWithCandidatesEmpty
+            ExpandedCandidatesDetached,
+            CandidatesEmpty to (adapter.candidates.size <= adapter.offset)
         )
         offsetJob?.cancel()
         offsetJob = null

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardStateMachine.kt
@@ -23,24 +23,21 @@ object ClipboardStateMachine {
     enum class TransitionEvent(val builder: TransitionBuildBlock<State, BooleanKey>) :
         EventStateMachine.TransitionEvent<State, BooleanKey> by BuildTransitionEvent(builder) {
         ClipboardDbUpdated({
-            from(Normal) transitTo AddMore on { it(ClipboardDbEmpty) == true }
-            from(AddMore) transitTo Normal on { it(ClipboardDbEmpty) == false }
+            from(Normal) transitTo AddMore on (ClipboardDbEmpty to true)
+            from(AddMore) transitTo Normal on (ClipboardDbEmpty to false)
         }),
         ClipboardListeningUpdated({
-            from(Normal) transitTo EnableListening on { it(ClipboardListeningEnabled) == false }
-            from(EnableListening) transitTo Normal on {
-                it(ClipboardListeningEnabled) == true && it(
-                    ClipboardDbEmpty
-                ) == false
+            from(Normal) transitTo EnableListening on (ClipboardListeningEnabled to false)
+            from(EnableListening) transitTo Normal onF {
+                it(ClipboardListeningEnabled) == true && it(ClipboardDbEmpty) == false
             }
-            from(EnableListening) transitTo AddMore on {
-                it(ClipboardListeningEnabled) == true && it(
-                    ClipboardDbEmpty
-                ) == true
+            from(EnableListening) transitTo AddMore onF {
+                it(ClipboardListeningEnabled) == true && it(ClipboardDbEmpty) == true
             }
-            from(AddMore) transitTo EnableListening on { it(ClipboardListeningEnabled) == false }
+            from(AddMore) transitTo EnableListening on (ClipboardListeningEnabled to false)
         })
     }
+
     fun new(initialState: State, block: (State) -> Unit) =
         EventStateMachine<State, TransitionEvent, BooleanKey>(initialState).apply {
             onNewStateListener = block

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -14,7 +14,7 @@ import org.fcitx.fcitx5.android.core.InputMethodEntry
 import org.fcitx.fcitx5.android.data.prefs.AppPrefs
 import org.fcitx.fcitx5.android.input.FcitxInputMethodService
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarComponent
-import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.KeyboardSwitchedOutNumberWithCapFlagsPassword
+import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.KeyboardSwitchedOutNumber
 import org.fcitx.fcitx5.android.input.bar.KawaiiBarStateMachine.TransitionEvent.KeyboardSwitchedToNumber
 import org.fcitx.fcitx5.android.input.broadcast.InputBroadcastReceiver
 import org.fcitx.fcitx5.android.input.dependency.fcitx
@@ -26,7 +26,6 @@ import org.fcitx.fcitx5.android.input.popup.PopupComponent
 import org.fcitx.fcitx5.android.input.wm.EssentialWindow
 import org.fcitx.fcitx5.android.input.wm.InputWindow
 import org.fcitx.fcitx5.android.input.wm.InputWindowManager
-import org.fcitx.fcitx5.android.utils.isInPasswordMode
 import org.mechdancer.dependency.manager.must
 import splitties.views.dsl.core.add
 import splitties.views.dsl.core.frameLayout
@@ -179,7 +178,7 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
     private fun notifyBarLayoutChanged() {
         if (currentKeyboardName == NumberKeyboard.Name)
             bar.barStateMachine.push(KeyboardSwitchedToNumber)
-        else if (service.isInPasswordMode)
-            bar.barStateMachine.push(KeyboardSwitchedOutNumberWithCapFlagsPassword)
+        else
+            bar.barStateMachine.push(KeyboardSwitchedOutNumber)
     }
 }

--- a/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
@@ -3,95 +3,147 @@ package org.fcitx.fcitx5.android.utils
 import org.fcitx.fcitx5.android.data.prefs.AppPrefs
 import timber.log.Timber
 
-class EventStateMachine<State : Any, Event : Any>(
-    initialState: State,
-    private val stateGraph: ImmutableGraph<State, List<Event>>
+class EventStateMachine<State : Any, Event : EventStateMachine.TransitionEvent<State, B>, B : EventStateMachine.BooleanStateKey>(
+    private val initialState: State,
+    private val externalBooleanStates: MutableMap<B, Boolean> = mutableMapOf()
 ) {
 
-    private var currentStateIx = stateGraph.vertices.indexOf(initialState)
+    interface BooleanStateKey {
+        val name: String
+    }
+
+    interface TransitionEvent<State : Any, B : BooleanStateKey> {
+        /**
+         * INVARIANT: No side effects
+         * @return the next state
+         */
+        fun accept(initialState: State, currentState: State, useBoolean: (B) -> Boolean?): State
+
+    }
 
     var onNewStateListener: ((State) -> Unit)? = null
 
-    val currentState
-        get() = stateGraph.vertices[currentStateIx]
+    var currentState = initialState
+        private set
 
     private val enableDebugLog: Boolean by AppPrefs.getInstance().internal.verboseLog
-
-    private val knownEvents by lazy { stateGraph.labels.flatten() }
 
     /**
      * Push an event that may trigger a transition of state
      */
     fun push(event: Event) {
-        if (event !in knownEvents)
-            throw IllegalArgumentException("$event is an unknown event")
-        val transitions = stateGraph.getEdgesOfVertexWithIndex(currentState)
-        val filtered = transitions.filter { event in it.second.label }
-        when (filtered.size) {
-            0 -> {
-                // do nothing
-                if (enableDebugLog)
-                    Timber.d("At $currentState ignored $event. All transitions ${transitions.map { it.second.label.joinToString() }} did not match")
-            }
-            1 -> {
-                if (enableDebugLog)
-                    Timber.d("At $currentState transited to ${filtered.first().second.vertex2}. Transition $event was matched")
-                currentStateIx = filtered.first().first.first
-                onNewStateListener?.invoke(filtered.first().second.vertex2)
-            }
-            else -> throw IllegalStateException("More than one transitions are found given $event on $currentState")
+        val newState = event.accept(initialState, currentState) { externalBooleanStates[it] }
+        if (newState == currentState) {
+            if (enableDebugLog)
+                Timber.d("At $currentState, $event didn't change the state")
+            return
         }
+        currentState = newState
+        onNewStateListener?.invoke(newState)
     }
 
+    /**
+     * Update boolean states and push an event
+     */
+    fun push(event: Event, vararg booleanStates: Pair<B, Boolean>) {
+        booleanStates.forEach {
+            setBooleanState(it.first, it.second)
+        }
+        push(event)
+    }
+
+    fun setBooleanState(key: B, value: Boolean) {
+        externalBooleanStates[key] = value
+    }
+
+    fun getBooleanState(key: B) =
+        externalBooleanStates[key]
+
+    fun unsafeJump(state: State) {
+        currentState = state
+        onNewStateListener?.invoke(state)
+    }
 }
 
-
 // DSL
+class TransitionEventBuilder<State : Any, B : EventStateMachine.BooleanStateKey> {
 
-fun <State : Any, Event : Any> eventStateMachine(
-    initialState: State,
-    builder: EventStateMachineBuilder<State, Event>.() -> Unit
-) =
-    EventStateMachineBuilder<State, Event>(initialState).apply(builder).build()
+    private val enableDebugLog: Boolean by AppPrefs.getInstance().internal.verboseLog
 
-class EventStateMachineBuilder<State : Any, Event : Any>(
-    private val initialState: State
-) {
-    private val map = mutableMapOf<Pair<State, State>, MutableList<Event>>()
+    private var raw: ((State, State, (B) -> Boolean?) -> State)? = null
 
-    private var listener: ((State) -> Unit)? = null
-
-    inner class EventTransitionBuilder(val startState: State) {
-        lateinit var endState: State
-        lateinit var event: Event
-
+    inner class Builder(val source: State) {
+        lateinit var target: State
+        var pred: ((B) -> Boolean?) -> Boolean = { _ -> true }
     }
 
-    infix fun EventTransitionBuilder.transitTo(state: State) = apply {
-        endState = state
+    infix fun Builder.transitTo(state: State) = apply {
+        target = state
     }
 
-    infix fun EventTransitionBuilder.on(event: Event) = run {
-        this.event = event
-        if (startState to endState !in map)
-            map[startState to endState] = mutableListOf(event)
-        else
-            map.getValue(startState to endState) += event
+    infix fun Builder.on(pred: ((B) -> Boolean?) -> Boolean) = apply {
+        this.pred = pred
     }
 
-    fun from(state: State) = EventTransitionBuilder(state)
+    val builders = mutableListOf<Builder>()
 
-    fun onNewState(block: (State) -> Unit) {
-        listener = block
+    fun from(state: State) = Builder(state).also { builders += it }
+
+    /**
+     * Use either [from] or [accept] to build the transition event
+     */
+    fun accept(block: ((State, State, (B) -> Boolean?) -> State)) = apply {
+        raw = block
     }
 
 
-    fun build() = EventStateMachine(
-        initialState,
-        ImmutableGraph(map.map { (k, v) ->
-            ImmutableGraph.Edge(k.first, k.second, v)
-        })
-    ).apply {
-        listener?.let { onNewStateListener = it }
+    fun build() =
+        object : EventStateMachine.TransitionEvent<State, B> {
+            override fun accept(
+                initialState: State,
+                currentState: State,
+                useBoolean: (B) -> Boolean?
+            ): State {
+                if (raw != null)
+                    return raw!!(initialState, currentState, useBoolean)
+                val filtered = builders.mapNotNull {
+                    it.takeIf {
+                        (it.source == currentState) && it.pred(useBoolean)
+                    }
+                }
+                return when (filtered.size) {
+                    0 -> currentState
+                    1 -> filtered.first().target
+                    else -> {
+                        val first = filtered.first().target
+                        if (enableDebugLog)
+                            Timber.d(
+                                "More than one target states at $currentState: ${
+                                    filtered.joinToString(
+                                        separator = ", "
+                                    )
+                                }. Take the first one: $first"
+                            )
+                        first
+                    }
+                }
+            }
+        }
+}
+
+typealias TransitionBuildBlock<State, B> = TransitionEventBuilder<State, B>.() -> Unit
+
+class BuildTransitionEvent<State : Any, B : EventStateMachine.BooleanStateKey>(block: TransitionBuildBlock<State, B>) :
+    EventStateMachine.TransitionEvent<State, B> {
+    private val delegate: EventStateMachine.TransitionEvent<State, B> by lazy {
+        TransitionEventBuilder<State, B>().also(block).build()
     }
+
+    override fun accept(
+        initialState: State,
+        currentState: State,
+        useBoolean: (B) -> Boolean?
+    ): State =
+        delegate.accept(initialState, currentState, useBoolean)
+
 }

--- a/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
@@ -81,7 +81,11 @@ class TransitionEventBuilder<State : Any, B : EventStateMachine.BooleanStateKey>
         target = state
     }
 
-    infix fun Builder.on(pred: ((B) -> Boolean?) -> Boolean) = apply {
+    infix fun Builder.on(expected: Pair<B, Boolean>) = apply {
+        this.pred = { it(expected.first) == expected.second }
+    }
+
+    infix fun Builder.onF(pred: ((B) -> Boolean?) -> Boolean) = apply {
         this.pred = pred
     }
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
@@ -123,13 +123,7 @@ class TransitionEventBuilder<State : Any, B : EventStateMachine.BooleanStateKey>
                     else -> {
                         val first = filtered.first().target
                         if (enableDebugLog)
-                            Timber.d(
-                                "More than one target states at $currentState: ${
-                                    filtered.joinToString(
-                                        separator = ", "
-                                    )
-                                }. Take the first one: $first"
-                            )
+                            Timber.d("More than one target states at $currentState: ${filtered.joinToString()}. Take the first one: $first")
                         first
                     }
                 }

--- a/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
@@ -112,16 +112,12 @@ class TransitionEventBuilder<State : Any, B : EventStateMachine.BooleanStateKey>
             ): State {
                 if (raw != null)
                     return raw!!(initialState, currentState, useBoolean)
-                val filtered = builders.mapNotNull {
-                    it.takeIf {
-                        (it.source == currentState) && it.pred(useBoolean)
-                    }
-                }
+                val filtered = builders.filter { it.source == currentState && it.pred(useBoolean) }
                 return when (filtered.size) {
                     0 -> currentState
-                    1 -> filtered.first().target
+                    1 -> filtered[0].target
                     else -> {
-                        val first = filtered.first().target
+                        val first = filtered[0].target
                         if (enableDebugLog)
                             Timber.d("More than one target states at $currentState: ${filtered.joinToString()}. Take the first one: $first")
                         first

--- a/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/utils/EventStateMachine.kt
@@ -38,6 +38,8 @@ class EventStateMachine<State : Any, Event : EventStateMachine.TransitionEvent<S
                 Timber.d("At $currentState, $event didn't change the state")
             return
         }
+        if (enableDebugLog)
+            Timber.d("At $currentState transited to $newState by $event")
         currentState = newState
         onNewStateListener?.invoke(newState)
     }

--- a/app/src/main/java/org/fcitx/fcitx5/android/utils/ImmutableGraph.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/utils/ImmutableGraph.kt
@@ -25,14 +25,6 @@ class ImmutableGraph<V, L>(
         }
     }
 
-    fun getEdgesOfVertexWithIndex(vertex: V) = adjacencyMatrix[vertices.indexOf(vertex)]
-        .asIterable()
-        .mapIndexedNotNull { v2Idx, labelIdx ->
-            labelIdx.takeIf { it != -1 }?.run {
-                (v2Idx to labelIdx) to Edge(vertex, vertices[v2Idx], labels[labelIdx])
-            }
-        }
-
     /**
      * @param predicate: whether to continue searching after this node
      */


### PR DESCRIPTION
Currently, event state machine uses an immutable graph as the underlying implementation, where events are stored as the edges in the graph. When an event is pushed to the state machine, we traverse all edges connected to the current state node, find the matched one, and go to the next state according to the edge. However, statically constructed state graph is not powerful enough in some cases, and thus more events, or transitions are needed. Although the logic encoded in state machines is naturally a graph, there is no remarkable reason (other than performance) to stick to a immutable graph data structure.

In this PR, the static graph is dropped - instead, each event decides what the next state should be:

```kotlin
    interface TransitionEvent<State : Any, B : BooleanStateKey> {
        fun accept(initialState: State, currentState: State, useBoolean: (B) -> Boolean?): State
    }
```

Event state machine itself does not save events, but only:

* initial state (may be used by events)
* current state
* a table of boolean values that event may depend on

All information is encoded in the event being pushed to the state machine, rather in the state machine. For the sake of convenience, a DSL is provided to construct event in a way that looks static, since it might be verbose to write `accept()` by hand in some simple cases. When using the `TransitionEventBuilder`, keep in mind that only the first satisfied transition is used, although there are multiple transitions defined in one block. This means the order of `from(...)` matters. Also, when the block contains `accept { ... }`, all other transitions will be ignored.
