### PR TITLE
Qualify the names of actions and permissions with applicationId

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,16 +19,16 @@
 
     <queries>
         <intent>
-            <action android:name="org.fcitx.fcitx5.android.plugin.MANIFEST" />
+            <action android:name="${applicationId}.plugin.MANIFEST" />
         </intent>
     </queries>
 
     <permission
-        android:name="org.fcitx.fcitx5.android.permission.IPC"
+        android:name="${applicationId}.permission.IPC"
         android:protectionLevel="signature" />
 
     <permission
-        android:name="org.fcitx.fcitx5.android.permission.BROADCAST"
+        android:name="${applicationId}.permission.BROADCAST"
         android:protectionLevel="signature" />
 
     <application
@@ -127,9 +127,9 @@
         <service
             android:name=".FcitxRemoteService"
             android:exported="true"
-            android:permission="org.fcitx.fcitx5.android.permission.IPC">
+            android:permission="${applicationId}.permission.IPC">
             <intent-filter>
-                <action android:name="org.fcitx.fcitx5.android.IPC" />
+                <action android:name="${applicationId}.IPC" />
             </intent-filter>
         </service>
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/FcitxApplication.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/FcitxApplication.kt
@@ -14,6 +14,7 @@ import org.fcitx.fcitx5.android.data.clipboard.ClipboardManager
 import org.fcitx.fcitx5.android.data.prefs.AppPrefs
 import org.fcitx.fcitx5.android.data.theme.ThemeManager
 import org.fcitx.fcitx5.android.ui.main.LogActivity
+import org.fcitx.fcitx5.android.utils.Broadcaster
 import org.fcitx.fcitx5.android.utils.Locales
 import org.fcitx.fcitx5.android.utils.isDarkMode
 import timber.log.Timber
@@ -72,7 +73,7 @@ class FcitxApplication : Application() {
         ClipboardManager.init(applicationContext)
         ThemeManager.init(resources.configuration)
         Locales.onLocaleChange(resources.configuration)
-        sendBroadcast(Intent(Broadcasts.FcitxApplicationCreated),Broadcasts.PERMISSION)
+        Broadcaster.broadcast(this) { it.FcitxApplicationCreated }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/core/data/DataManager.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/core/data/DataManager.kt
@@ -26,7 +26,7 @@ import kotlin.concurrent.withLock
  */
 object DataManager {
 
-    const val PLUGIN_INTENT = "${BuildConfig.APPLICATION_ID}.MANIFEST"
+    const val PLUGIN_INTENT = "${BuildConfig.APPLICATION_ID}.plugin.MANIFEST"
 
     private val lock = ReentrantLock()
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/core/data/DataManager.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/core/data/DataManager.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.fcitx.fcitx5.android.BuildConfig
 import org.fcitx.fcitx5.android.core.data.DataManager.dataDir
 import org.fcitx.fcitx5.android.utils.Const
 import org.fcitx.fcitx5.android.utils.appContext
@@ -25,7 +26,7 @@ import kotlin.concurrent.withLock
  */
 object DataManager {
 
-    const val PLUGIN_INTENT = "org.fcitx.fcitx5.android.plugin.MANIFEST"
+    const val PLUGIN_INTENT = "${BuildConfig.APPLICATION_ID}.MANIFEST"
 
     private val lock = ReentrantLock()
 
@@ -74,7 +75,6 @@ object DataManager {
 
         val pm = appContext.packageManager
 
-        val isDebugBuild = Const.buildType == "debug"
         val pluginPackages = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             pm.queryIntentActivities(
                 Intent(PLUGIN_INTENT),
@@ -83,10 +83,8 @@ object DataManager {
         } else {
             @Suppress("DEPRECATION")
             pm.queryIntentActivities(Intent(PLUGIN_INTENT), PackageManager.MATCH_ALL)
-        }.mapNotNull {
-            // Only consider plugin with the same build variant as app's
-            val packageName = it.activityInfo.packageName
-            if (isDebugBuild == packageName.endsWith(".debug")) packageName else null
+        }.map {
+           it.activityInfo.packageName
         }
 
         Timber.d("Detected plugin packages: ${pluginPackages.joinToString()}")

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt
@@ -45,6 +45,7 @@ import org.fcitx.fcitx5.android.data.theme.Theme
 import org.fcitx.fcitx5.android.data.theme.ThemeManager
 import org.fcitx.fcitx5.android.input.cursor.CursorRange
 import org.fcitx.fcitx5.android.input.cursor.CursorTracker
+import org.fcitx.fcitx5.android.utils.Broadcaster
 import org.fcitx.fcitx5.android.utils.alpha
 import org.fcitx.fcitx5.android.utils.inputConnection
 import splitties.bitflags.hasFlag
@@ -122,7 +123,7 @@ class FcitxInputMethodService : LifecycleInputMethodService() {
         }
         ThemeManager.addOnChangedListener(onThemeChangeListener)
         super.onCreate()
-        sendBroadcast(Intent(Broadcasts.FcitxInputMethodServiceCreated), Broadcasts.PERMISSION)
+        Broadcaster.broadcast(this) { it.FcitxInputMethodServiceCreated }
     }
 
     private fun handleFcitxEvent(event: FcitxEvent<*>) {
@@ -710,7 +711,7 @@ class FcitxInputMethodService : LifecycleInputMethodService() {
         super.onDestroy()
         // Fcitx might be used in super.onDestroy()
         FcitxDaemon.disconnect(javaClass.name)
-        sendBroadcast(Intent(Broadcasts.FcitxInputMethodServiceDestroyed), Broadcasts.PERMISSION)
+        Broadcaster.broadcast(this) { it.FcitxInputMethodServiceDestroyed }
     }
 
     companion object {

--- a/app/src/main/java/org/fcitx/fcitx5/android/utils/Broadcaster.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/utils/Broadcaster.kt
@@ -1,0 +1,12 @@
+package org.fcitx.fcitx5.android.utils
+
+import android.content.Context
+import android.content.Intent
+import org.fcitx.fcitx5.android.BuildConfig
+import org.fcitx.fcitx5.android.common.Broadcasts
+
+object Broadcaster {
+    private val broadcasts by lazy { Broadcasts(BuildConfig.APPLICATION_ID) }
+    fun broadcast(context: Context, action: (Broadcasts) -> String) =
+        context.sendBroadcast(Intent(action(broadcasts)), broadcasts.PERMISSION)
+}

--- a/build-logic/convention/src/main/kotlin/AndroidPluginAppConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidPluginAppConventionPlugin.kt
@@ -12,6 +12,24 @@ class AndroidPluginAppConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.extensions.configure<BaseAppModuleExtension> {
+            buildTypes {
+                release {
+                    buildConfigField("String", "MAIN_APPLICATION_ID", "\"org.fcitx.fcitx5.android\"")
+                    addManifestPlaceholders(
+                        mapOf(
+                            "mainApplicationId" to "org.fcitx.fcitx5.android",
+                        )
+                    )
+                }
+                debug {
+                    buildConfigField("String", "MAIN_APPLICATION_ID", "\"org.fcitx.fcitx5.android.debug\"")
+                    addManifestPlaceholders(
+                        mapOf(
+                            "mainApplicationId" to "org.fcitx.fcitx5.android.debug",
+                        )
+                    )
+                }
+            }
             applicationVariants.all {
                 val pluginsTaskName = "assemble${name.capitalized()}Plugins"
                 val pluginsTask = target.rootProject.tasks.findByName(pluginsTaskName)

--- a/lib/common/src/main/java/org/fcitx/fcitx5/android/common/Broadcasts.kt
+++ b/lib/common/src/main/java/org/fcitx/fcitx5/android/common/Broadcasts.kt
@@ -2,8 +2,15 @@ package org.fcitx.fcitx5.android.common
 
 @Suppress("PropertyName")
 class Broadcasts(applicationId: String) {
+    @JvmField
     val FcitxInputMethodServiceCreated = "$applicationId.IME_SERVICE_CREATED"
+
+    @JvmField
     val FcitxInputMethodServiceDestroyed = "$applicationId.IME_SERVICE_DESTROYED"
+
+    @JvmField
     val FcitxApplicationCreated = "$applicationId.APP_CREATED"
+
+    @JvmField
     val PERMISSION = "$applicationId.permission.BROADCAST"
 }

--- a/lib/common/src/main/java/org/fcitx/fcitx5/android/common/Broadcasts.kt
+++ b/lib/common/src/main/java/org/fcitx/fcitx5/android/common/Broadcasts.kt
@@ -4,6 +4,6 @@ package org.fcitx.fcitx5.android.common
 class Broadcasts(applicationId: String) {
     val FcitxInputMethodServiceCreated = "$applicationId.IME_SERVICE_CREATED"
     val FcitxInputMethodServiceDestroyed = "$applicationId.IME_SERVICE_DESTROYED"
-    val FcitxApplicationCreated = "$applicationId.android.APP_CREATED"
-    val PERMISSION = "$applicationId.android.permission.BROADCAST"
+    val FcitxApplicationCreated = "$applicationId.APP_CREATED"
+    val PERMISSION = "$applicationId.permission.BROADCAST"
 }

--- a/lib/common/src/main/java/org/fcitx/fcitx5/android/common/Broadcasts.kt
+++ b/lib/common/src/main/java/org/fcitx/fcitx5/android/common/Broadcasts.kt
@@ -1,8 +1,9 @@
 package org.fcitx.fcitx5.android.common
 
-object Broadcasts {
-    const val FcitxInputMethodServiceCreated = "org.fcitx.fcitx5.android.IME_SERVICE_CREATED"
-    const val FcitxInputMethodServiceDestroyed = "org.fcitx.fcitx5.android.IME_SERVICE_DESTROYED"
-    const val FcitxApplicationCreated = "org.fcitx.fcitx5.android.APP_CREATED"
-    const val PERMISSION = "org.fcitx.fcitx5.android.permission.BROADCAST"
+@Suppress("PropertyName")
+class Broadcasts(applicationId: String) {
+    val FcitxInputMethodServiceCreated = "$applicationId.IME_SERVICE_CREATED"
+    val FcitxInputMethodServiceDestroyed = "$applicationId.IME_SERVICE_DESTROYED"
+    val FcitxApplicationCreated = "$applicationId.android.APP_CREATED"
+    val PERMISSION = "$applicationId.android.permission.BROADCAST"
 }

--- a/lib/common/src/main/java/org/fcitx/fcitx5/android/common/ipc/FcitxRemoteConnection.kt
+++ b/lib/common/src/main/java/org/fcitx/fcitx5/android/common/ipc/FcitxRemoteConnection.kt
@@ -7,15 +7,14 @@ import android.content.ServiceConnection
 import android.os.IBinder
 
 fun Context.bindFcitxRemoteService(
-    debugBuild: Boolean,
+    mainApplicationId: String,
     onDisconnect: () -> Unit = {},
     onConnected: (IFcitxRemoteService) -> Unit
 ): FcitxRemoteConnection {
     val connection = FcitxRemoteConnection(onConnected, onDisconnect)
     bindService(
-        Intent("org.fcitx.fcitx5.android.IPC").apply {
-            val pkgName = "org.fcitx.fcitx5.android" + if (debugBuild) ".debug" else ""
-            setPackage(pkgName)
+        Intent("$mainApplicationId.IPC").apply {
+            setPackage(mainApplicationId)
         },
         connection,
         Context.BIND_AUTO_CREATE

--- a/lib/plugin-base/build.gradle.kts
+++ b/lib/plugin-base/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         }
     }
     publishing {
-        singleVariant("release")
+        multipleVariants { allVariants() }
     }
 }
 
@@ -39,7 +39,7 @@ publishing {
         }
     }
     publications {
-        register<MavenPublication>("release") {
+        register<MavenPublication>("default") {
             groupId = "org.fcitx.fcitx5.android.lib"
             artifactId = "plugin_base"
             pom {
@@ -49,7 +49,7 @@ publishing {
                 }
             }
             afterEvaluate {
-                from(components["release"])
+                from(components["default"])
             }
         }
     }

--- a/lib/plugin-base/src/debug/AndroidManifest.xml
+++ b/lib/plugin-base/src/debug/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <queries>
-        <package android:name="org.fcitx.fcitx5.android"/>
+        <package android:name="org.fcitx.fcitx5.android.debug"/>
     </queries>
 
     <application>
@@ -11,7 +11,7 @@
             android:exported="true"
             android:theme="@style/DeviceSettingsTheme">
             <intent-filter>
-                <action android:name="org.fcitx.fcitx5.android.plugin.MANIFEST" />
+                <action android:name="org.fcitx.fcitx5.android.debug.plugin.MANIFEST" />
             </intent-filter>
         </activity>
     </application>

--- a/lib/plugin-base/src/debug/AndroidManifest.xml
+++ b/lib/plugin-base/src/debug/AndroidManifest.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <queries>
-        <package android:name="org.fcitx.fcitx5.android.debug"/>
+        <package
+            android:name="org.fcitx.fcitx5.android"
+            tools:node="remove" />
+        <package android:name="org.fcitx.fcitx5.android.debug" />
     </queries>
 
     <application>
@@ -10,6 +14,11 @@
             android:name=".AboutActivity"
             android:exported="true"
             android:theme="@style/DeviceSettingsTheme">
+            <intent-filter>
+                <action
+                    android:name="org.fcitx.fcitx5.android.plugin.MANIFEST"
+                    tools:node="remove" />
+            </intent-filter>
             <intent-filter>
                 <action android:name="org.fcitx.fcitx5.android.debug.plugin.MANIFEST" />
             </intent-filter>

--- a/plugin/clipboard-filter/src/main/AndroidManifest.xml
+++ b/plugin/clipboard-filter/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="org.fcitx.fcitx5.android.permission.IPC" />
-    <uses-permission android:name="org.fcitx.fcitx5.android.permission.BROADCAST" />
+    <uses-permission android:name="${mainApplicationId}.permission.IPC" />
+    <uses-permission android:name="${mainApplicationId}.permission.BROADCAST" />
 
     <application android:label="@string/app_name">
         <service
@@ -12,7 +12,7 @@
             android:name=".FcitxAppCreatedBroadcastReceiver"
             android:exported="true">
             <intent-filter>
-                <action android:name="org.fcitx.fcitx5.android.APP_CREATED" />
+                <action android:name="${mainApplicationId}.APP_CREATED" />
             </intent-filter>
         </receiver>
     </application>

--- a/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/ClearURLsService.kt
+++ b/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/ClearURLsService.kt
@@ -25,7 +25,7 @@ class ClearURLsService : JobService() {
     }
 
     override fun onStartJob(params: JobParameters): Boolean {
-        connection = bindFcitxRemoteService(BuildConfig.BUILD_TYPE == "debug") {
+        connection = bindFcitxRemoteService(BuildConfig.MAIN_APPLICATION_ID) {
             Log.d("ClearURLsService", "bind to fcitx")
             it.registerClipboardEntryTransformer(transformer)
         }


### PR DESCRIPTION
## 拉取请求 / Pull request

#### 问题追踪 / Issue tracker
<!--
这会自动关闭相关的问题工单
Fixes will automatically close the related issue
-->

Permissions in debug variant clash with those in release variant 

#### 功能特点 / Feature
<!--
描述拉取请求的功能和特点
Describe feature of pull request
-->

`org.fcitx.fcitx5.android` won't be hardcoded to the name of permission and action in intent filter; instead, plugins with debug vairant will have `mainApplication = org.fcitx.fcitx5.android.debug` available in manifest and build config.  


#### 附加信息 / Additional Info
