### PR TITLE
Add preference for return to keyboard after paste

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/data/prefs/AppPrefs.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/data/prefs/AppPrefs.kt
@@ -315,6 +315,9 @@ class AppPrefs(private val sharedPreferences: SharedPreferences) {
             Int.MAX_VALUE,
             "s"
         ) { clipboardListening.getValue() && clipboardSuggestion.getValue() }
+        val clipboardReturnAfterPaste = switch(
+            R.string.clipboard_return_after_paste, "clipboard_return_after_paste", false
+        ) { clipboardListening.getValue() }
     }
 
     private val providers = mutableListOf<ManagedPreferenceProvider>()

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardWindow.kt
@@ -33,9 +33,12 @@ import org.fcitx.fcitx5.android.input.clipboard.ClipboardStateMachine.Transition
 import org.fcitx.fcitx5.android.input.clipboard.ClipboardStateMachine.TransitionEvent.ClipboardListeningUpdated
 import org.fcitx.fcitx5.android.input.dependency.inputMethodService
 import org.fcitx.fcitx5.android.input.dependency.theme
+import org.fcitx.fcitx5.android.input.keyboard.KeyboardWindow
 import org.fcitx.fcitx5.android.input.wm.InputWindow
+import org.fcitx.fcitx5.android.input.wm.InputWindowManager
 import org.fcitx.fcitx5.android.utils.AppUtil
 import org.fcitx.fcitx5.android.utils.EventStateMachine
+import org.mechdancer.dependency.manager.must
 import splitties.dimensions.dp
 import splitties.resources.styledColor
 import splitties.views.dsl.core.withTheme
@@ -44,6 +47,7 @@ import kotlin.properties.Delegates
 class ClipboardWindow : InputWindow.ExtendedInputWindow<ClipboardWindow>() {
 
     private val service: FcitxInputMethodService by manager.inputMethodService()
+    private val windowManager: InputWindowManager by manager.must()
     private val theme by manager.theme()
 
     private val snackbarCtx by lazy {
@@ -66,6 +70,7 @@ class ClipboardWindow : InputWindow.ExtendedInputWindow<ClipboardWindow>() {
     }
 
     private val clipboardEnabledPref = AppPrefs.getInstance().clipboard.clipboardListening
+    private val clipboardReturnAfterPaste by AppPrefs.getInstance().clipboard.clipboardReturnAfterPaste
 
     private val clipboardEntriesPager by lazy {
         Pager(PagingConfig(pageSize = 16)) { ClipboardManager.allEntries() }
@@ -96,6 +101,7 @@ class ClipboardWindow : InputWindow.ExtendedInputWindow<ClipboardWindow>() {
 
             override fun onPaste(entry: ClipboardEntry) {
                 service.commitText(entry.text)
+                if (clipboardReturnAfterPaste) windowManager.attachWindow(KeyboardWindow)
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,4 +233,5 @@
     <string name="following_system_settings">Follow system settings</string>
     <string name="button_sound">Sound on keypress</string>
     <string name="button_sound_volume">Keypress sound volume</string>
+    <string name="clipboard_return_after_paste">Return after paste</string>
 </resources>


### PR DESCRIPTION
#### Issue tracker
<!--
这会自动关闭相关的问题工单
Fixes will automatically close the related issue
-->

Fixes #298

#### Feature
Add "Return after paste" option in Clipboard preferences. When enabled, immediately return to keyboard after pasting an item from the ClipboardWindow.
