### PR TITLE
Set default ECM_DIR to homebrew on macOS

### DIFF
--- a/lib/fcitx5/src/main/cpp/cmake/FindECM.cmake
+++ b/lib/fcitx5/src/main/cpp/cmake/FindECM.cmake
@@ -1,5 +1,7 @@
 if(DEFINED ENV{ECM_DIR})
     set(ECM_DIR $ENV{ECM_DIR})
+elseif(CMAKE_HOST_APPLE)
+    set(ECM_DIR /opt/homebrew/share/ECM/cmake)
 else()
     set(ECM_DIR /usr/share/ECM/cmake)
 endif()


### PR DESCRIPTION
Homebrew is the de facto standard package manager on macOS. Set `ECM_DIR` so that no need to configure environment variable after `brew install extra-cmake-modules`.
Ref: https://github.com/Homebrew/homebrew-core/blob/fbced5509d9bbe829ea60bd809d05d29585db9c4/Formula/e/extra-cmake-modules.rb#L48
Tested on m1 macOS 13.5.1 with Homebrew 4.1.10.