### PR TITLE
apply theme to TextEditingUi + editable clipboard content radius

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/data/theme/ThemePrefs.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/data/theme/ThemePrefs.kt
@@ -76,6 +76,9 @@ class ThemePrefs(sharedPreferences: SharedPreferences) :
 
     val keyRadius = int(R.string.key_radius, "key_radius", 4, 0, 48, "dp")
 
+    val clipboardEntryRadius =
+        int(R.string.clipboard_entry_radius, "clipboard_entry_radius", 2, 0, 48, "dp")
+
     enum class PunctuationPosition {
         Bottom,
         TopRight;

--- a/app/src/main/java/org/fcitx/fcitx5/android/data/theme/ThemePrefs.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/data/theme/ThemePrefs.kt
@@ -76,6 +76,9 @@ class ThemePrefs(sharedPreferences: SharedPreferences) :
 
     val keyRadius = int(R.string.key_radius, "key_radius", 4, 0, 48, "dp")
 
+    val textEditingButtonRadius =
+        int(R.string.text_editing_button_radius, "text_editing_button_radius", 8, 0, 48, "dp")
+
     val clipboardEntryRadius =
         int(R.string.clipboard_entry_radius, "clipboard_entry_radius", 2, 0, 48, "dp")
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardAdapter.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardAdapter.kt
@@ -22,6 +22,7 @@ import kotlin.math.min
 
 abstract class ClipboardAdapter(
     private val theme: Theme,
+    private val entryRadius: Float,
     private val maskSensitive: Boolean
 ) : PagingDataAdapter<ClipboardEntry, ClipboardAdapter.ViewHolder>(diffCallback) {
 
@@ -87,7 +88,7 @@ abstract class ClipboardAdapter(
     class ViewHolder(val entryUi: ClipboardEntryUi) : RecyclerView.ViewHolder(entryUi.root)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder =
-        ViewHolder(ClipboardEntryUi(parent.context, theme))
+        ViewHolder(ClipboardEntryUi(parent.context, theme, entryRadius))
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val entry = getItem(position) ?: return

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardEntryUi.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardEntryUi.kt
@@ -31,7 +31,7 @@ import splitties.views.dsl.core.wrapContent
 import splitties.views.imageDrawable
 import splitties.views.setPaddingDp
 
-class ClipboardEntryUi(override val ctx: Context, private val theme: Theme) : Ui {
+class ClipboardEntryUi(override val ctx: Context, private val theme: Theme, radius: Float) : Ui {
 
     val textView = textView {
         minLines = 1
@@ -62,7 +62,6 @@ class ClipboardEntryUi(override val ctx: Context, private val theme: Theme) : Ui
     override val root = CustomGestureView(ctx).apply {
         isClickable = true
         minimumHeight = dp(30)
-        val radius = dp(2f)
         foreground = RippleDrawable(
             ColorStateList.valueOf(theme.keyPressHighlightColor), null,
             GradientDrawable().apply {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/clipboard/ClipboardWindow.kt
@@ -29,6 +29,7 @@ import org.fcitx.fcitx5.android.data.clipboard.ClipboardManager
 import org.fcitx.fcitx5.android.data.clipboard.db.ClipboardEntry
 import org.fcitx.fcitx5.android.data.prefs.AppPrefs
 import org.fcitx.fcitx5.android.data.prefs.ManagedPreference
+import org.fcitx.fcitx5.android.data.theme.ThemeManager
 import org.fcitx.fcitx5.android.input.FcitxInputMethodService
 import org.fcitx.fcitx5.android.input.clipboard.ClipboardStateMachine.BooleanKey.ClipboardDbEmpty
 import org.fcitx.fcitx5.android.input.clipboard.ClipboardStateMachine.BooleanKey.ClipboardListeningEnabled
@@ -74,13 +75,19 @@ class ClipboardWindow : InputWindow.ExtendedInputWindow<ClipboardWindow>() {
     private val clipboardReturnAfterPaste by prefs.clipboardReturnAfterPaste
     private val clipboardMaskSensitive by prefs.clipboardMaskSensitive
 
+    private val clipboardEntryRadius by ThemeManager.prefs.clipboardEntryRadius
+
     private val clipboardEntriesPager by lazy {
         Pager(PagingConfig(pageSize = 16)) { ClipboardManager.allEntries() }
     }
     private var adapterSubmitJob: Job? = null
 
     private val adapter: ClipboardAdapter by lazy {
-        object : ClipboardAdapter(this@ClipboardWindow.theme, clipboardMaskSensitive) {
+        object : ClipboardAdapter(
+            theme,
+            context.dp(clipboardEntryRadius.toFloat()),
+            clipboardMaskSensitive
+        ) {
             override fun onPin(id: Int) {
                 service.lifecycleScope.launch { ClipboardManager.pin(id) }
             }

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/editing/TextEditingButton.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/editing/TextEditingButton.kt
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * SPDX-FileCopyrightText: Copyright 2024 Fcitx5 for Android Contributors
+ */
+
+package org.fcitx.fcitx5.android.input.editing
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.InsetDrawable
+import android.graphics.drawable.LayerDrawable
+import android.graphics.drawable.RippleDrawable
+import android.graphics.drawable.StateListDrawable
+import androidx.annotation.DrawableRes
+import org.fcitx.fcitx5.android.data.theme.Theme
+import org.fcitx.fcitx5.android.input.keyboard.CustomGestureView
+import org.fcitx.fcitx5.android.utils.borderDrawable
+import org.fcitx.fcitx5.android.utils.pressHighlightDrawable
+import org.fcitx.fcitx5.android.utils.rippleDrawable
+import splitties.dimensions.dp
+import splitties.views.dsl.core.add
+import splitties.views.dsl.core.imageView
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.wrapContent
+import splitties.views.gravityCenter
+import splitties.views.imageResource
+import kotlin.math.max
+
+@SuppressLint("ViewConstructor")
+class TextEditingButton(
+    ctx: Context,
+    private val theme: Theme,
+    private val rippled: Boolean,
+    private val bordered: Boolean,
+    private val radius: Float,
+    private val altStyle: Boolean = false
+) : CustomGestureView(ctx) {
+
+    // bordered
+    private val shadowWidth = dp(1)
+    private val hMargin = dp(4)
+    private val vMargin = dp(4)
+
+    // !bordered
+    private val lineWidth = max(1, dp(1) / 2)
+
+    init {
+        if (bordered) {
+            background = LayerDrawable(
+                arrayOf(
+                    GradientDrawable().apply {
+                        cornerRadius = radius
+                        setColor(theme.keyShadowColor)
+                    },
+                    GradientDrawable().apply {
+                        cornerRadius = radius
+                        setColor(if (altStyle) theme.altKeyBackgroundColor else theme.keyBackgroundColor)
+                    }
+                )
+            ).apply {
+                setLayerInset(0, hMargin, vMargin, hMargin, vMargin - shadowWidth)
+                setLayerInset(1, hMargin, vMargin, hMargin, vMargin)
+            }
+            if (rippled) {
+                foreground = RippleDrawable(
+                    ColorStateList.valueOf(theme.keyPressHighlightColor), null,
+                    // ripple should be masked with an opaque color
+                    InsetDrawable(
+                        GradientDrawable().apply {
+                            cornerRadius = radius
+                            setColor(Color.WHITE)
+                        },
+                        hMargin, vMargin, hMargin, vMargin
+                    )
+                )
+            } else {
+                foreground = StateListDrawable().apply {
+                    addState(
+                        intArrayOf(android.R.attr.state_pressed),
+                        // use mask drawable as highlight directly
+                        InsetDrawable(
+                            GradientDrawable().apply {
+                                cornerRadius = radius
+                                setColor(theme.keyPressHighlightColor)
+                            },
+                            hMargin, vMargin, hMargin, vMargin
+                        )
+                    )
+                }
+            }
+        } else {
+            background = borderDrawable(lineWidth, theme.dividerColor)
+            foreground =
+                if (rippled) rippleDrawable(theme.keyPressHighlightColor)
+                else pressHighlightDrawable(theme.keyPressHighlightColor)
+        }
+    }
+
+    val textView = textView {
+        isClickable = false
+        isFocusable = false
+        background = null
+        setTextColor(if (altStyle) theme.altKeyTextColor else theme.keyTextColor)
+    }
+
+    val imageView = imageView {
+        isClickable = false
+        isFocusable = false
+        imageTintList = ColorStateList.valueOf(theme.altKeyTextColor)
+    }
+
+    fun setText(id: Int) {
+        textView.setText(id)
+        removeView(imageView)
+        add(textView, lParams(wrapContent, wrapContent, gravityCenter))
+    }
+
+    fun setIcon(@DrawableRes icon: Int) {
+        imageView.imageResource = icon
+        removeView(textView)
+        add(imageView, lParams(wrapContent, wrapContent, gravityCenter))
+    }
+
+    fun enableActivatedState() {
+        textView.setTextColor(
+            ColorStateList(
+                arrayOf(
+                    intArrayOf(android.R.attr.state_activated),
+                    intArrayOf(android.R.attr.state_enabled)
+                ),
+                intArrayOf(
+                    theme.genericActiveForegroundColor,
+                    if (altStyle) theme.altKeyTextColor else theme.keyTextColor
+                )
+            )
+        )
+        imageView.imageTintList = ColorStateList(
+            arrayOf(
+                intArrayOf(android.R.attr.state_activated),
+                intArrayOf(android.R.attr.state_enabled)
+            ),
+            intArrayOf(
+                theme.genericActiveForegroundColor,
+                theme.altKeyTextColor
+            )
+        )
+        if (bordered) {
+            background = StateListDrawable().apply {
+                addState(
+                    intArrayOf(android.R.attr.state_activated),
+                    LayerDrawable(
+                        arrayOf(
+                            GradientDrawable().apply {
+                                cornerRadius = radius
+                                setColor(theme.keyShadowColor)
+                            },
+                            GradientDrawable().apply {
+                                cornerRadius = radius
+                                setColor(theme.genericActiveBackgroundColor)
+                            }
+                        )
+                    ).apply {
+                        setLayerInset(0, hMargin, vMargin, hMargin, vMargin - shadowWidth)
+                        setLayerInset(1, hMargin, vMargin, hMargin, vMargin)
+                    }
+                )
+                addState(
+                    intArrayOf(android.R.attr.state_enabled),
+                    LayerDrawable(
+                        arrayOf(
+                            GradientDrawable().apply {
+                                cornerRadius = radius
+                                setColor(theme.keyShadowColor)
+                            },
+                            GradientDrawable().apply {
+                                cornerRadius = radius
+                                setColor(theme.keyBackgroundColor)
+                            }
+                        )
+                    ).apply {
+                        setLayerInset(0, hMargin, vMargin, hMargin, vMargin - shadowWidth)
+                        setLayerInset(1, hMargin, vMargin, hMargin, vMargin)
+                    }
+                )
+            }
+        } else {
+            background = StateListDrawable().apply {
+                addState(
+                    intArrayOf(android.R.attr.state_activated),
+                    borderDrawable(
+                        lineWidth,
+                        theme.dividerColor,
+                        theme.genericActiveBackgroundColor
+                    )
+                )
+                addState(
+                    intArrayOf(android.R.attr.state_enabled),
+                    borderDrawable(lineWidth, theme.dividerColor)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/editing/TextEditingUi.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/editing/TextEditingUi.kt
@@ -5,22 +5,14 @@
 package org.fcitx.fcitx5.android.input.editing
 
 import android.content.Context
-import android.content.res.ColorStateList
-import android.graphics.drawable.StateListDrawable
 import android.view.View
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.fcitx.fcitx5.android.R
 import org.fcitx.fcitx5.android.data.InputFeedbacks
 import org.fcitx.fcitx5.android.data.theme.Theme
-import org.fcitx.fcitx5.android.data.theme.ThemeManager
 import org.fcitx.fcitx5.android.input.bar.ui.ToolButton
-import org.fcitx.fcitx5.android.input.keyboard.CustomGestureView
-import org.fcitx.fcitx5.android.utils.borderDrawable
-import org.fcitx.fcitx5.android.utils.pressHighlightDrawable
-import org.fcitx.fcitx5.android.utils.rippleDrawable
 import splitties.dimensions.dp
-import splitties.resources.drawable
 import splitties.views.dsl.constraintlayout.above
 import splitties.views.dsl.constraintlayout.below
 import splitties.views.dsl.constraintlayout.bottomOfParent
@@ -34,64 +26,25 @@ import splitties.views.dsl.constraintlayout.topOfParent
 import splitties.views.dsl.core.Ui
 import splitties.views.dsl.core.add
 import splitties.views.dsl.core.horizontalLayout
-import splitties.views.dsl.core.imageView
 import splitties.views.dsl.core.lParams
-import splitties.views.dsl.core.textView
-import splitties.views.dsl.core.wrapContent
-import splitties.views.gravityCenter
-import splitties.views.imageDrawable
-import splitties.views.padding
 
-class TextEditingUi(override val ctx: Context, private val theme: Theme) : Ui {
+class TextEditingUi(
+    override val ctx: Context,
+    private val theme: Theme,
+    private val ripple: Boolean,
+    private val border: Boolean,
+    private val radius: Float
+) : Ui {
 
-    private val keyRippleEffect by ThemeManager.prefs.keyRippleEffect
-
-    private val borderWidth = ctx.dp(1) / 2
-
-    private fun View.applyBorderedBackground() {
-        background = borderDrawable(borderWidth, theme.dividerColor)
-        foreground =
-            if (keyRippleEffect) rippleDrawable(theme.keyPressHighlightColor)
-            else pressHighlightDrawable(theme.keyPressHighlightColor)
-    }
-
-    class GTextButton(context: Context) : CustomGestureView(context) {
-        val text = textView {
-            isClickable = false
-            isFocusable = false
-            background = null
+    private fun textButton(@StringRes id: Int, altStyle: Boolean = false) =
+        TextEditingButton(ctx, theme, ripple, border, radius, altStyle).apply {
+            setText(id)
         }
 
-        init {
-            add(text, lParams(wrapContent, wrapContent, gravityCenter))
+    private fun iconButton(@DrawableRes icon: Int, altStyle: Boolean = false) =
+        TextEditingButton(ctx, theme, ripple, border, radius, altStyle).apply {
+            setIcon(icon)
         }
-    }
-
-    class GImageButton(context: Context) : CustomGestureView(context) {
-        val image = imageView {
-            isClickable = false
-            isFocusable = false
-        }
-
-        init {
-            add(image, lParams(wrapContent, wrapContent, gravityCenter))
-        }
-    }
-
-    private fun textButton(@StringRes id: Int) = GTextButton(ctx).apply {
-        text.setText(id)
-        text.setTextColor(theme.keyTextColor)
-        stateListAnimator = null
-        applyBorderedBackground()
-    }
-
-    private fun iconButton(@DrawableRes icon: Int) = GImageButton(ctx).apply {
-        image.imageDrawable = drawable(icon)!!.apply {
-            setTint(theme.altKeyTextColor)
-        }
-        padding = dp(10)
-        applyBorderedBackground()
-    }
 
     val upButton = iconButton(R.drawable.ic_baseline_keyboard_arrow_up_24)
 
@@ -102,44 +55,24 @@ class TextEditingUi(override val ctx: Context, private val theme: Theme) : Ui {
     val leftButton = iconButton(R.drawable.ic_baseline_keyboard_arrow_left_24)
 
     val selectButton = textButton(R.string.select).apply {
-        text.setTextColor(
-            ColorStateList(
-                arrayOf(
-                    intArrayOf(android.R.attr.state_activated),
-                    intArrayOf(android.R.attr.state_enabled)
-                ),
-                intArrayOf(theme.genericActiveForegroundColor, theme.keyTextColor)
-            )
-        )
-        background = StateListDrawable().apply {
-            addState(
-                intArrayOf(android.R.attr.state_activated),
-                borderDrawable(
-                    borderWidth,
-                    theme.dividerColor,
-                    theme.genericActiveBackgroundColor
-                )
-            )
-            addState(
-                intArrayOf(android.R.attr.state_enabled),
-                borderDrawable(borderWidth, theme.dividerColor)
-            )
-        }
+        enableActivatedState()
     }
 
     val homeButton = iconButton(R.drawable.ic_baseline_first_page_24)
 
     val endButton = iconButton(R.drawable.ic_baseline_last_page_24)
 
-    val selectAllButton = textButton(android.R.string.selectAll)
+    val selectAllButton = textButton(android.R.string.selectAll, altStyle = true)
 
-    val cutButton = textButton(android.R.string.cut).apply { visibility = View.GONE }
+    val cutButton = textButton(android.R.string.cut, altStyle = true).apply {
+        visibility = View.GONE
+    }
 
-    val copyButton = textButton(android.R.string.copy)
+    val copyButton = textButton(android.R.string.copy, altStyle = true)
 
-    val pasteButton = textButton(android.R.string.paste)
+    val pasteButton = textButton(android.R.string.paste, altStyle = true)
 
-    val backspaceButton = iconButton(R.drawable.ic_baseline_backspace_24).apply {
+    val backspaceButton = iconButton(R.drawable.ic_baseline_backspace_24, altStyle = true).apply {
         soundEffect = InputFeedbacks.SoundEffect.Delete
     }
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/editing/TextEditingWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/editing/TextEditingWindow.kt
@@ -7,6 +7,7 @@ package org.fcitx.fcitx5.android.input.editing
 import android.view.KeyEvent
 import android.view.View
 import org.fcitx.fcitx5.android.R
+import org.fcitx.fcitx5.android.data.theme.ThemeManager
 import org.fcitx.fcitx5.android.input.FcitxInputMethodService
 import org.fcitx.fcitx5.android.input.broadcast.InputBroadcastReceiver
 import org.fcitx.fcitx5.android.input.clipboard.ClipboardWindow
@@ -24,6 +25,10 @@ class TextEditingWindow : InputWindow.ExtendedInputWindow<TextEditingWindow>(),
     private val windowManager: InputWindowManager by manager.must()
     private val theme by manager.theme()
 
+    private val buttonRipple by ThemeManager.prefs.keyRippleEffect
+    private val buttonBorder by ThemeManager.prefs.keyBorder
+    private val buttonRadius by ThemeManager.prefs.textEditingButtonRadius
+
     private var hasSelection = false
     private var userSelection = false
 
@@ -32,7 +37,7 @@ class TextEditingWindow : InputWindow.ExtendedInputWindow<TextEditingWindow>(),
     }
 
     private val ui by lazy {
-        TextEditingUi(context, theme).apply {
+        TextEditingUi(context, theme, buttonRipple, buttonBorder, buttonRadius.toFloat()).apply {
             fun CustomGestureView.onClickWithRepeating(block: () -> Unit) {
                 setOnClickListener { block() }
                 repeatEnabled = true

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerPageUi.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerPageUi.kt
@@ -4,6 +4,7 @@
  */
 package org.fcitx.fcitx5.android.input.picker
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.view.ViewGroup
 import org.fcitx.fcitx5.android.R
@@ -43,7 +44,12 @@ import splitties.views.dsl.core.Ui
 import splitties.views.dsl.core.add
 import splitties.views.dsl.core.matchParent
 
-class PickerPageUi(override val ctx: Context, val theme: Theme, private val density: Density) : Ui {
+class PickerPageUi(
+    override val ctx: Context,
+    theme: Theme,
+    density: Density,
+    bordered: Boolean = false
+) : Ui {
 
     enum class Density(
         val pageSize: Int,
@@ -63,15 +69,7 @@ class PickerPageUi(override val ctx: Context, val theme: Theme, private val dens
     }
 
     companion object {
-        val BackspaceAppearance = Appearance.Image(
-            src = R.drawable.ic_baseline_backspace_24,
-            variant = Variant.Alternative,
-            border = Border.Off,
-            viewId = R.id.button_backspace
-        )
-
         val BackspaceAction = SymAction(KeySym(FcitxKeyMapping.FcitxKey_BackSpace))
-
         private var popupOnKeyPress by AppPrefs.getInstance().keyboard.popupOnKeyPress
     }
 
@@ -82,7 +80,7 @@ class PickerPageUi(override val ctx: Context, val theme: Theme, private val dens
         displayText = "",
         textSize = density.textSize,
         variant = Variant.Normal,
-        border = Border.Off
+        border = if (bordered) Border.On else Border.Off
     )
 
     private val keyViews = Array(density.pageSize) {
@@ -96,7 +94,14 @@ class PickerPageUi(override val ctx: Context, val theme: Theme, private val dens
         }
     }
 
-    private val backspaceKey = ImageKeyView(ctx, theme, BackspaceAppearance).apply {
+    private val backspaceAppearance = Appearance.Image(
+        src = R.drawable.ic_baseline_backspace_24,
+        variant = Variant.Alternative,
+        border = if (bordered) Border.On else Border.Off,
+        viewId = R.id.button_backspace
+    )
+
+    private val backspaceKey = ImageKeyView(ctx, theme, backspaceAppearance).apply {
         setOnClickListener { onBackspaceClick() }
         repeatEnabled = true
         onRepeatListener = { onBackspaceClick() }
@@ -204,6 +209,7 @@ class PickerPageUi(override val ctx: Context, val theme: Theme, private val dens
             keyView.apply {
                 if (i >= items.size) {
                     isEnabled = false
+                    @SuppressLint("SetTextI18n")
                     mainText.text = ""
                     setOnClickListener(null)
                     setOnLongClickListener(null)

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerPagesAdapter.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerPagesAdapter.kt
@@ -16,8 +16,9 @@ class PickerPagesAdapter(
     private val keyActionListener: KeyActionListener,
     private val popupActionListener: PopupActionListener,
     data: List<Pair<PickerData.Category, Array<String>>>,
-    val density: PickerPageUi.Density,
-    recentlyUsedFileName: String
+    private val density: PickerPageUi.Density,
+    recentlyUsedFileName: String,
+    private val bordered: Boolean = false
 ) : RecyclerView.Adapter<PickerPagesAdapter.ViewHolder>() {
 
     class ViewHolder(val ui: PickerPageUi) : RecyclerView.ViewHolder(ui.root)
@@ -110,7 +111,7 @@ class PickerPagesAdapter(
     override fun getItemCount() = pages.size
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        return ViewHolder(PickerPageUi(parent.context, theme, density))
+        return ViewHolder(PickerPageUi(parent.context, theme, density, bordered))
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerWindow.kt
@@ -12,6 +12,7 @@ import androidx.transition.Transition
 import androidx.viewpager2.widget.ViewPager2
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.fcitx.fcitx5.android.data.theme.ThemeManager
 import org.fcitx.fcitx5.android.input.broadcast.ReturnKeyDrawableComponent
 import org.fcitx.fcitx5.android.input.dependency.inputMethodService
 import org.fcitx.fcitx5.android.input.dependency.theme
@@ -30,10 +31,11 @@ import org.mechdancer.dependency.manager.must
 
 class PickerWindow(
     override val key: Key,
-    val data: List<Pair<PickerData.Category, Array<String>>>,
-    val density: PickerPageUi.Density,
+    private val data: List<Pair<PickerData.Category, Array<String>>>,
+    private val density: PickerPageUi.Density,
     private val switchKey: KeyDef,
-    val popupPreview: Boolean = true
+    private val popupPreview: Boolean = true,
+    private val followKeyBorder: Boolean = true
 ) : InputWindow.ExtendedInputWindow<PickerWindow>(), EssentialWindow {
 
     enum class Key : EssentialWindow.Key {
@@ -48,6 +50,8 @@ class PickerWindow(
     private val commonKeyActionListener: CommonKeyActionListener by manager.must()
     private val popup: PopupComponent by manager.must()
     private val returnKeyDrawable: ReturnKeyDrawableComponent by manager.must()
+
+    private val keyBorder by ThemeManager.prefs.keyBorder
 
     private lateinit var pickerLayout: PickerLayout
     private lateinit var pickerPagesAdapter: PickerPagesAdapter
@@ -116,8 +120,9 @@ class PickerWindow(
 
     override fun onCreateView() = PickerLayout(context, theme, switchKey).apply {
         pickerLayout = this
+        val bordered = followKeyBorder && keyBorder
         pickerPagesAdapter = PickerPagesAdapter(
-            theme, keyActionListener, popupActionListener, data, density, key.name
+            theme, keyActionListener, popupActionListener, data, density, key.name, bordered
         )
         tabsUi.apply {
             setTabs(pickerPagesAdapter.categories)

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerWindowPreset.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerWindowPreset.kt
@@ -21,14 +21,16 @@ fun emojiPicker(): PickerWindow = PickerWindow(
     key = PickerWindow.Key.Emoji,
     data = PickerData.Emoji,
     density = PickerPageUi.Density.Medium,
-    popupPreview = false,
     switchKey = TextPickerSwitchKey(":-)", PickerWindow.Key.Emoticon),
+    popupPreview = false,
+    followKeyBorder = false
 )
 
 fun emoticonPicker(): PickerWindow = PickerWindow(
     key = PickerWindow.Key.Emoticon,
     data = PickerData.Emoticon,
     density = PickerPageUi.Density.Low,
+    switchKey = ImagePickerSwitchKey(R.drawable.ic_baseline_tag_faces_24, PickerWindow.Key.Emoji),
     popupPreview = false,
-    switchKey = ImagePickerSwitchKey(R.drawable.ic_baseline_tag_faces_24, PickerWindow.Key.Emoji)
+    followKeyBorder = false
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="key_border">Enable key border</string>
     <string name="brightness">Brightness</string>
     <string name="key_radius">Key radius</string>
+    <string name="text_editing_button_radius">Text editing button radius</string>
     <string name="clipboard_entry_radius">Clipboard entry radius</string>
     <string name="key_horizontal_margin">Key horizontal margin</string>
     <string name="key_vertical_margin">Key vertical margin</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="key_border">Enable key border</string>
     <string name="brightness">Brightness</string>
     <string name="key_radius">Key radius</string>
+    <string name="clipboard_entry_radius">Clipboard entry radius</string>
     <string name="key_horizontal_margin">Key horizontal margin</string>
     <string name="key_vertical_margin">Key vertical margin</string>
     <string name="configure">Configure</string>


### PR DESCRIPTION
# Text Editing UI
![image](https://github.com/fcitx5-android/fcitx5-android/assets/7237501/9ec22807-c4e4-4822-b0df-6b01148ae4c0)
![image](https://github.com/fcitx5-android/fcitx5-android/assets/7237501/71e89df2-09ac-47d1-a859-3029bd4433c5)
![image](https://github.com/fcitx5-android/fcitx5-android/assets/7237501/ad5f9920-d5c4-4bd5-9191-50a3032359dd)
![image](https://github.com/fcitx5-android/fcitx5-android/assets/7237501/0c7838b0-35ad-4ffd-a7fa-f5c7f85bbfbc)

# Symbol Key Border
![image](https://github.com/fcitx5-android/fcitx5-android/assets/7237501/e5d70ef7-6ead-4883-816c-86791a621101)
![image](https://github.com/fcitx5-android/fcitx5-android/assets/7237501/9fe4eed0-5057-402c-86ab-d50501aff827)
![image](https://github.com/fcitx5-android/fcitx5-android/assets/7237501/d4443298-1f5c-456f-9fda-d8dbe5490976)

# Clipboard Content Radius
![image](https://github.com/fcitx5-android/fcitx5-android/assets/7237501/e04e1c1f-f811-43dd-9283-ae9a57da6e52)
