### PR TITLE
feat: feat: add release button vibration feedback in settings

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/data/InputFeedbacks.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/data/InputFeedbacks.kt
@@ -41,6 +41,7 @@ object InputFeedbacks {
     private val soundOnKeyPress by AppPrefs.getInstance().keyboard.soundOnKeyPress
     private val soundOnKeyPressVolume by AppPrefs.getInstance().keyboard.soundOnKeyPressVolume
     private val hapticOnKeyPress by AppPrefs.getInstance().keyboard.hapticOnKeyPress
+    private val hapticOnKeyUp by AppPrefs.getInstance().keyboard.hapticOnKeyUp
     private val buttonPressVibrationMilliseconds by AppPrefs.getInstance().keyboard.buttonPressVibrationMilliseconds
     private val buttonLongPressVibrationMilliseconds by AppPrefs.getInstance().keyboard.buttonLongPressVibrationMilliseconds
     private val buttonPressVibrationAmplitude by AppPrefs.getInstance().keyboard.buttonPressVibrationAmplitude
@@ -53,13 +54,13 @@ object InputFeedbacks {
 
     private val audioManager = appContext.audioManager
 
-    fun hapticFeedback(view: View, longPress: Boolean = false) {
+    fun hapticFeedback(view: View, longPress: Boolean = false, keyUp: Boolean = false) {
         when (hapticOnKeyPress) {
             InputFeedbackMode.Enabled -> {}
             InputFeedbackMode.Disabled -> return
             InputFeedbackMode.FollowingSystem -> if (!systemHapticFeedback) return
         }
-
+        if (keyUp == true && hapticOnKeyUp == false) return
         val duration: Long
         val amplitude: Int
         val hfc: Int

--- a/app/src/main/java/org/fcitx/fcitx5/android/data/prefs/AppPrefs.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/data/prefs/AppPrefs.kt
@@ -62,6 +62,11 @@ class AppPrefs(private val sharedPreferences: SharedPreferences) {
                     R.string.disabled
                 )
             )
+        val hapticOnKeyUp = switch(
+            R.string.button_up_haptic_feedback,
+            "haptic_on_keyup",
+            false
+        ){ hapticOnKeyPress.getValue() != InputFeedbackMode.Disabled }
         val buttonPressVibrationMilliseconds: ManagedPreference.PInt
         val buttonLongPressVibrationMilliseconds: ManagedPreference.PInt
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/CustomGestureView.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/CustomGestureView.kt
@@ -180,6 +180,7 @@ open class CustomGestureView(ctx: Context) : FrameLayout(ctx) {
             }
             MotionEvent.ACTION_UP -> {
                 isPressed = false
+                InputFeedbacks.hapticFeedback(this, longPress = true,keyUp = true)
                 dispatchGestureEvent(GestureType.Up, event.x, event.y)
                 val shouldPerformClick = !(touchMovedOutside ||
                         longPressTriggered ||

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -14,6 +14,7 @@
     <string name="hide_key_config">隐藏快捷键配置</string>
     <string name="_not_available_">（不可用）</string>
     <string name="button_haptic_feedback">按键时振动</string>
+    <string name="button_up_haptic_feedback">按键松开时振动</string>
     <string name="button_vibration_milliseconds">按键振动时长</string>
     <string name="button_press">短按</string>
     <string name="button_long_press">长按</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="hide_key_config">Hide hotkey configurations</string>
     <string name="_not_available_">(Not Available)</string>
     <string name="button_haptic_feedback">Haptic feedback on keypress</string>
+    <string name="button_up_haptic_feedback">Haptic feedback on keyup</string>
     <string name="button_vibration_milliseconds">Keypress vibration duration</string>
     <string name="button_press">Press</string>
     <string name="button_long_press">Long press</string>


### PR DESCRIPTION
添加抬键振动反馈功能，主要参考了小艺输入法（原百度输入法华为版）的模拟机械键盘手感的功能。设置项在`设置->键盘->按键松开时震动`，默认关闭，打开后在`InputFeedbacks`的`hapticFeedback`方法和`CustomGestureView::onTouchEvent::MotionEvent.ACTION_UP`代码块内调用。