### PR TITLE
Exclude redundant files from apk

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidAppConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidAppConventionPlugin.kt
@@ -2,13 +2,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  * SPDX-FileCopyrightText: Copyright 2021-2023 Fcitx5 for Android Contributors
  */
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import com.android.build.gradle.tasks.PackageApplication
 import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension
 import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
+import org.gradle.api.internal.provider.Providers
 import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
+import java.lang.reflect.Field
 
 /**
  * The prototype of an Android Application
@@ -52,6 +59,68 @@ class AndroidAppConventionPlugin : AndroidBaseConventionPlugin() {
             }
             compileOptions {
                 isCoreLibraryDesugaringEnabled = true
+            }
+        }
+
+        target.extensions.configure<ApplicationExtension> {
+            dependenciesInfo {
+                includeInApk = false
+                includeInBundle = false
+            }
+            packaging {
+                resources {
+                    excludes += setOf(
+                        "/META-INF/*.version",
+                        "/META-INF/*.kotlin_module",  // cannot be excluded actually
+                        "/kotlin/**",
+                        "/kotlin-tooling-metadata.json"
+                    )
+                }
+            }
+        }
+
+        // remove META-INF/com/android/build/gradle/app-metadata.properties
+        target.tasks.withType<PackageApplication> {
+            var javaClass: Class<*>? = appMetadata.javaClass
+            var valueField: Field? = null
+            while (javaClass != null) {
+                valueField = javaClass.declaredFields.find { it.name == "value" }
+                if (valueField != null) break
+                else javaClass = javaClass.superclass
+            }
+            valueField?.isAccessible = true
+            var appMetadataPath: String? = null
+            target.afterEvaluate {
+                // writeReleaseAppMetadata was skipped... but why?
+                if (appMetadata.isPresent) {
+                    appMetadata.asFile.get().apply {
+                        appMetadataPath = path
+                        parentFile.mkdirs()
+                        // make sure appMetadata file exists before the task
+                        writeText("")
+                    }
+                }
+            }
+            doFirst {
+                appMetadataPath?.let { File(it).delete() }
+                valueField?.set(appMetadata, Providers.notDefined<RegularFile>())
+                allInputFilesWithNameOnlyPathSensitivity.removeAll { true }
+            }
+        }
+
+        // try to remove <pkg_name>-<version_name>.kotlin_module, but it does not work ¯\_(ツ)_/¯
+        target.tasks.withType<KotlinCompile> {
+            doLast f@{
+                val ktClass = outputs.files.files.filter { it.path.contains("kotlin-classes") }
+                if (ktClass.isEmpty()) return@f
+                val metaInf = ktClass.first().resolve("META-INF")
+                if (!metaInf.exists() || !metaInf.isDirectory) return@f
+                metaInf.listFiles()?.forEach {
+                    if (it.name.endsWith(".kotlin_module")) {
+                        println("deleting ${it.path}")
+                        it.delete()
+                    }
+                }
             }
         }
 

--- a/build-logic/convention/src/main/kotlin/AndroidBaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidBaseConventionPlugin.kt
@@ -26,6 +26,13 @@ open class AndroidBaseConventionPlugin : Plugin<Project> {
                 sourceCompatibility = Versions.java
                 targetCompatibility = Versions.java
             }
+            buildTypes {
+                onEach {
+                    // remove META-INF/version-control-info.textproto
+                    @Suppress("UnstableApiUsage")
+                    it.vcsInfo.include = false
+                }
+            }
         }
 
         target.tasks.withType<KotlinCompile> {
@@ -38,6 +45,28 @@ open class AndroidBaseConventionPlugin : Plugin<Project> {
         target.extensions.configure<KotlinProjectExtension> {
             sourceSets.all {
                 languageSettings.optIn("kotlin.RequiresOptIn")
+            }
+        }
+
+        target.afterEvaluate {
+            // remove assets/dexopt/baseline.prof{,m} (baseline profile)
+            target.tasks.findByName("prepareReleaseArtProfile")?.apply {
+                enabled = false
+            }
+            target.tasks.findByName("mergeReleaseArtProfile")?.apply {
+                enabled = false
+            }
+            target.tasks.findByName("expandReleaseL8ArtProfileWildcards")?.apply {
+                enabled = false
+            }
+            target.tasks.findByName("expandReleaseArtProfileWildcards")?.apply {
+                enabled = false
+            }
+            target.tasks.findByName("compileReleaseArtProfile")?.apply {
+                enabled = false
+            }
+            target.tasks.findByName("writeReleaseAppMetadata")?.apply {
+                enabled = false
             }
         }
     }


### PR DESCRIPTION
Because `/assets/dexopt/baseline.prof` is not reproducible: https://github.com/fcitx5-android/fcitx5-android/actions/runs/10133331430/job/28018377144

Also try to remove as many as unnecessary files, such as `/META-INF/com/android/build/gradle/app-metadata.properties`.

---

References:
- https://gist.github.com/obfusk/61046e09cee352ae6dd109911534b12e#fix-proposed-by-linsui-disable-baseline-profiles
- https://gitlab.com/fdroid/admin/-/issues/367
- https://youtrack.jetbrains.com/issue/KT-9770
- https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/PackageAndroidArtifact.kt;drc=4e42339f2cc4d3c1fd6f0ce84a6436fd04235a1b;l=122
- https://github.com/DroidKaigi/conference-app-2019/issues/268#issuecomment-457836813