### PR TITLE
Disable menu group divider on Honor MagicOS devices

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/input/status/StatusAreaWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/status/StatusAreaWindow.kt
@@ -101,7 +101,7 @@ class StatusAreaWindow : InputWindow.ExtendedInputWindow<StatusAreaWindow>(),
                         val popup = PopupMenu(context, view)
                         val menu = popup.menu
                         val hasDivider =
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && !DeviceUtil.isHMOS) {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && !DeviceUtil.isHMOS && !DeviceUtil.isHonorMagicOS) {
                                 menu.setGroupDividerEnabled(true)
                                 true
                             } else {

--- a/app/src/main/java/org/fcitx/fcitx5/android/utils/DeviceUtil.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/utils/DeviceUtil.kt
@@ -38,4 +38,8 @@ object DeviceUtil {
         getSystemProperty("ro.vivo.os.version").isNotEmpty()
     }
 
+    val isHonorMagicOS: Boolean by lazy {
+        getSystemProperty("ro.magic.systemversion").isNotEmpty()
+    }
+
 }


### PR DESCRIPTION
disable group divider on Honor MagicOS devices

before:

![image](https://github.com/user-attachments/assets/c9c90d12-31f7-40e7-b004-639ef6dc9e81)


after:

![image](https://github.com/user-attachments/assets/afe5260c-85c5-4ed9-87af-fa8ab469d9e8)
