### PR TITLE
Make ClearURLs compliant with the JavaScript implementation

### DIFF
--- a/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/ClearURLs.kt
+++ b/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/ClearURLs.kt
@@ -47,8 +47,10 @@ object ClearURLs {
         )["providers"]
     }
 
+    private val urlPattern = Regex("^https?://", RegexOption.IGNORE_CASE)
+
     fun transform(text: String): String {
-        if (!text.startsWith("http"))
+        if (!urlPattern.containsMatchIn(text))
             return text
         var x = text
         var matched = false

--- a/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/ClearURLs.kt
+++ b/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/ClearURLs.kt
@@ -5,6 +5,8 @@
 package org.fcitx.fcitx5.android.plugin.clipboard_filter
 
 import android.content.res.AssetManager
+import android.net.Uri
+import android.net.UrlQuerySanitizer
 import android.util.Log
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -13,17 +15,21 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import java.net.URLDecoder
 
+typealias RegexAsString = @Serializable(with = RegexSerializer::class) Regex
+typealias SearchParam = UrlQuerySanitizer.ParameterValuePair
+typealias SearchParams = List<UrlQuerySanitizer.ParameterValuePair>
 
 object ClearURLs {
     @Serializable
     data class ClearURLsProvider(
-        val urlPattern: String,
+        /** all patterns starts with https? */
+        val urlPattern: RegexAsString,
         val completeProvider: Boolean = false,
-        val rules: List<String>? = null,
-        val rawRules: List<String>? = null,
+        val rules: List<RegexAsString>? = null,
+        val rawRules: List<RegexAsString>? = null,
         val referralMarketing: List<String>? = null,
-        val exceptions: List<String>? = null,
-        val redirections: List<String>? = null,
+        val exceptions: List<RegexAsString>? = null,
+        val redirections: List<RegexAsString>? = null,
         val forceRedirection: Boolean = false
     )
 
@@ -42,40 +48,61 @@ object ClearURLs {
         )["providers"]
     }
 
+    private val querySanitizer = UrlQuerySanitizer().apply {
+        allowUnregisteredParamaters = true
+    }
+
     fun transform(text: String): String {
         var x = text
         catalog?.let { map ->
             for ((_, provider) in map) {
                 // matches url pattern
-                if (provider.urlPattern.toRegex().find(x) == null)
+                if (provider.urlPattern.find(x) == null)
                     continue
                 // not in exceptions
-                if (provider.exceptions?.any { it.toRegex().find(x) != null } == true)
+                if (provider.exceptions?.any { it.find(x) != null } == true)
                     continue
                 // apply redirections
                 provider.redirections?.forEach { redirection ->
-                    redirection.toRegex().find(x)?.let { matchResult ->
+                    redirection.find(x)?.let { matchResult ->
                         matchResult.groupValues.takeIf { it.size > 1 }?.let {
-                            val redir = decodeURL(it[1])
-                            x = redir
+                            x = decodeURL(it[1])
                         }
                     }
                 }
                 provider.rawRules?.forEach { rawRule ->
-                    val r = rawRule.toRegex()
-                    x = r.replace(x, "")
+                    x = rawRule.replace(x, "")
                 }
-                // apply rules
-                provider.rules?.forEach { rule ->
-                    val r = "(?:&amp;|[/?#&])$rule=[^&]*".toRegex()
-                    x = r.replace(x, "")
-                }
+                // apply rules (if any)
+                val result = provider.rules.takeIf { !it.isNullOrEmpty() }
+                    ?.let { rules ->
+                        val uri = Uri.parse(x)
+                        val newQuery = parseParams(uri.query).filterBy(rules).join()
+                        val newFragment = parseParams(uri.fragment).filterBy(rules).join()
+                        uri.buildUpon().encodedQuery(newQuery).fragment(newFragment).toString()
+                    } ?: x
+                Log.d("ClearURLs", "$text -> $result")
+                return result
             }
-            Log.d("ClearURLs", "$text -> $x")
+            // no matching rules
             return x
         } ?: throw IllegalStateException("Catalog is unavailable")
     }
 
     private fun decodeURL(url: String) =
         URLDecoder.decode(url.replace("+", "%2B"), "UTF-8").replace("%2B", "+")
+
+    private fun parseParams(str: String?): SearchParams {
+        if (str.isNullOrEmpty()) return emptyList()
+        querySanitizer.parseQuery(str)
+        return querySanitizer.parameterList
+    }
+
+    private fun SearchParams.filterBy(rules: List<Regex>) = filter { param ->
+        rules.all { !it.matches(param.mParameter) }
+    }
+
+    private fun SearchParam.join() = "${mParameter}=${mValue}"
+
+    private fun SearchParams.join() = joinToString("&") { it.join() }
 }

--- a/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/MainService.kt
+++ b/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/MainService.kt
@@ -29,7 +29,7 @@ class MainService : FcitxPluginService() {
 
     override fun start() {
         connection = bindFcitxRemoteService(BuildConfig.MAIN_APPLICATION_ID) {
-            Log.d("ClearURLsService", "Bind to fcitx remote")
+            log("Bind to fcitx remote")
             it.registerClipboardEntryTransformer(transformer)
         }
     }
@@ -39,7 +39,11 @@ class MainService : FcitxPluginService() {
             connection.remoteService?.unregisterClipboardEntryTransformer(transformer)
         }
         unbindService(connection)
-        Log.d("ClearURLsService", "Unbind from fcitx remote")
+        log("Unbind from fcitx remote")
+    }
+
+    private fun log(msg: String) {
+        Log.d("ClearURLsService", msg)
     }
 
 }

--- a/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/RegexSerializer.kt
+++ b/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/RegexSerializer.kt
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * SPDX-FileCopyrightText: Copyright 2024 Fcitx5 for Android Contributors
+ */
+
+package org.fcitx.fcitx5.android.plugin.clipboard_filter
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object RegexSerializer : KSerializer<Regex> {
+    override val descriptor = PrimitiveSerialDescriptor("RegexSerializer", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: Regex) = encoder.encodeString(value.toString())
+    override fun deserialize(decoder: Decoder) = Regex(decoder.decodeString())
+}

--- a/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/RegexSerializer.kt
+++ b/plugin/clipboard-filter/src/main/java/org/fcitx/fcitx5/android/plugin/clipboard_filter/RegexSerializer.kt
@@ -14,5 +14,10 @@ import kotlinx.serialization.encoding.Encoder
 object RegexSerializer : KSerializer<Regex> {
     override val descriptor = PrimitiveSerialDescriptor("RegexSerializer", PrimitiveKind.STRING)
     override fun serialize(encoder: Encoder, value: Regex) = encoder.encodeString(value.toString())
-    override fun deserialize(decoder: Decoder) = Regex(decoder.decodeString())
+
+    /**
+     * ClearURLs JavaScript implementation use regex flag "gi"
+     * https://github.com/ClearURLs/Addon/blob/deec80b763179fa5c3559a37e3c9a6f1b28d0886/clearurls.js#L94
+     */
+    override fun deserialize(decoder: Decoder) = Regex(decoder.decodeString(), RegexOption.IGNORE_CASE)
 }


### PR DESCRIPTION
Ref:

https://github.com/ClearURLs/Addon/blob/deec80b763179fa5c3559a37e3c9a6f1b28d0886/core_js/pureCleaning.js#L52

https://github.com/ClearURLs/Addon/blob/deec80b763179fa5c3559a37e3c9a6f1b28d0886/clearurls.js#L40

---

Test cases:

```
https://www.amazon.com/?a+b+c=a+b+c -> unchanged
https://href.li/?https://t.me/+foo -> https://t.me/+foo
https://www.google.com/url?q=http%3A%2F%2Fexample.com -> http://example.com
```