### PR TITLE
Update fcitx5-chewing.json License

### DIFF
--- a/plugin/chewing/licenses/libraries/fcitx5-chewing.json
+++ b/plugin/chewing/licenses/libraries/fcitx5-chewing.json
@@ -6,6 +6,6 @@
     "website": "https://github.com/fcitx/fcitx5-chewing",
     "tag": "native",
     "licenses": [
-        "GPL-2.0-or-later"
+        "LGPL-2.1-or-later"
     ]
 }


### PR DESCRIPTION
Updated license declaration to reflect changes in the dependent library's licensing."

Given the [website](https://github.com/fcitx/fcitx5-chewin)'s [license declaration](https://github.com/fcitx/fcitx5-chewing/blob/master/LICENSES/LGPL-2.1-or-later.txt), it no longer uses the GPL license; therefore, the license should be updated to reflect the changes in dependencies.