### PR TITLE
adjust mainText on space

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/core/Types.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/core/Types.kt
@@ -70,7 +70,10 @@ data class InputMethodEntry(
     constructor(name: String) : this("", name, "", "", "×", "", "", false)
 
     val displayName: String
-        get() = name.ifEmpty { uniqueName }
+        get() = when {
+            subMode.name.isNullOrEmpty() -> name.ifEmpty { uniqueName }
+            else -> label.ifEmpty { name.ifEmpty { uniqueName } }
+        }
 }
 
 @Parcelize

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
@@ -167,7 +167,7 @@ class TextKeyboard(
     override fun onInputMethodUpdate(ime: InputMethodEntry) {
         space.mainText.text = buildString {
             append(ime.displayName)
-            ime.subMode.run { label.ifEmpty { name.ifEmpty { null } } }?.let { append(" ($it)") }
+            ime.subMode.run { name.ifEmpty { label.ifEmpty { null } } }?.let { append(" $it") }
         }
         if (capsState != CapsState.None) {
             switchCapsState()


### PR DESCRIPTION
adjust mainText on space, mainly for input methods with submode

Here is the modified result：

![image](https://github.com/user-attachments/assets/d2f84b9d-91b8-4ace-acc6-86ae477a23ee)
![image](https://github.com/user-attachments/assets/ca992ebb-dee3-4619-a63c-7fe967cff9bc)

![image](https://github.com/user-attachments/assets/8b7b4597-ed43-44d8-b2ca-1b45b6ed9c49)
![image](https://github.com/user-attachments/assets/052ef044-3330-4164-a4d1-06d8eb533f7e)

![image](https://github.com/user-attachments/assets/405ea4be-a0b1-47bf-b2d4-8d255ede6673)
![image](https://github.com/user-attachments/assets/aa467130-9f08-4e39-9894-fbbce19db9f1)
![image](https://github.com/user-attachments/assets/e07ae56e-0016-4b8d-9f34-684c38c180da)


