### PR TITLE
Emoji skin tone selection in popup keyboard

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/input/popup/PopupComponent.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/popup/PopupComponent.kt
@@ -107,7 +107,7 @@ class PopupComponent :
     }
 
     private fun showKeyboard(viewId: Int, keyboard: KeyDef.Popup.Keyboard, bounds: Rect) {
-        val keys = PopupPreset[keyboard.label] ?: return
+        val keys = PopupPreset[keyboard.label] ?: getEmojiWithSkinTones(keyboard.label) ?: return
         // clear popup preview text         OR create empty popup preview
         showingEntryUi[viewId]?.setText("") ?: showPopup(viewId, "", bounds)
         reallyShowKeyboard(viewId, keys, bounds)

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/popup/PopupEmojiSkinTone.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/popup/PopupEmojiSkinTone.kt
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * SPDX-FileCopyrightText: Copyright 2025 Fcitx5 for Android Contributors
+ */
+
+package org.fcitx.fcitx5.android.input.popup
+
+import android.icu.lang.UCharacter
+import android.icu.lang.UProperty
+import android.os.Build
+
+val EmojiSkinTones = arrayOf("🏻", "🏼", "🏽", "🏾", "🏿")
+
+fun getEmojiWithSkinTones(emoji: String): Array<String>? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+        return null
+    }
+    val codePoints = emoji.codePoints().toArray()
+    val isEmojiModifierBase = Array(codePoints.size) {
+        UCharacter.hasBinaryProperty(codePoints[it], UProperty.EMOJI_MODIFIER_BASE)
+    }
+    if (isEmojiModifierBase.sumOf { (if (it) 1 else 0).toInt() } > 2) {
+        // bail if too crowded; eg. https://emojipedia.org/family-man-medium-light-skin-tone-woman-medium-light-skin-tone-girl-medium-light-skin-tone-boy-medium-light-skin-tone
+        return null
+    }
+    if (UCharacter.hasBinaryProperty(codePoints[0], UProperty.EMOJI_MODIFIER_BASE)) {
+        return Array(EmojiSkinTones.size) { i ->
+            val tone = EmojiSkinTones[i]
+            buildString {
+                codePoints.forEachIndexed { j, codePoint ->
+                    append(Character.toString(codePoint))
+                    if (isEmojiModifierBase[j]) append(tone)
+                }
+            }
+        }
+    }
+    return null
+}


### PR DESCRIPTION
[Property.EMOJI_MODIFIER_BASE](https://developer.android.com/reference/android/icu/lang/UProperty.html#EMOJI_MODIFIER_BASE) requires API 28 (Android 9.0)

![image](https://github.com/user-attachments/assets/4351dff7-2325-4901-b78c-87f913a94411)

Mostly works fine, but with

👪👨‍👨‍👦‍👦 unsupported

👨‍👦 buggy

👯 supported but requres newer font

Also needs an option for "preferred skin tone"

Closes #622