### PR TITLE
add hangul to keepComposingIMs

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/CommonKeyActionListener.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/CommonKeyActionListener.kt
@@ -64,7 +64,7 @@ class CommonKeyActionListener :
 
     private var backspaceSwipeState = Stopped
 
-    private val keepComposingIMs = arrayOf("keyboard-us", "unikey")
+    private val keepComposingIMs = arrayOf("keyboard-us", "unikey", "hangul")
 
     private suspend fun FcitxAPI.commitAndReset() {
         if (clientPreeditCached.isEmpty() && inputPanelCached.preedit.isEmpty()) {


### PR DESCRIPTION
Added hangul to keepComposingIMs to solve the issue that last character is erased when typing special characters.
Expected behavior is that the hangul text in preedit should be committed before typing special characters.