### PR TITLE
feat: Long press send for enter

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyDefPreset.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyDefPreset.kt
@@ -235,7 +235,7 @@ class ReturnKey(percentWidth: Float = 0.15f) : KeyDef(
         Popup.Menu(
             arrayOf(
                 Popup.Menu.Item(
-                    "Emoji", R.drawable.ic_baseline_tag_faces_24, KeyAction.PickerSwitchAction()
+                    "Enter", R.drawable.ic_baseline_keyboard_return_24, KeyAction.CommitAction("\n")
                 )
             )
         )


### PR DESCRIPTION
We can already enter the emoji panel by long pressing the comma button, so I think it'd be nice to change the behavior of long pressing the send button to insert a newline. This would come in handy in supported apps, like QQ or WeChat, if you've enabled "Send message by enter".