### PR TITLE
Remove yoga submodule on F-Droid build

### DIFF
--- a/app/org.fcitx.fcitx5.android.yml
+++ b/app/org.fcitx.fcitx5.android.yml
@@ -41,6 +41,7 @@ Builds:
       - lib/fcitx5/src/main/cpp/fcitx5/src/modules/unicode/charselectdata
     scandelete:
       - build-logic/convention/build
+      - lib/fcitx5/src/main/cpp/fcitx5/third_party/yoga
     build:
       - pushd $$fcitx5-android-prebuilder$$
       - ABI=%abi ANDROID_NDK_ROOT=$$NDK$$ CMAKE_VERSION=3.31.6 ANDROID_PLATFORM=23


### PR DESCRIPTION
AAR/JAR files in yoga would trigger ERRORs in F-Droid build, since Android does not have classicui, just remove yoga

```
INFO: Scanning source for common problems...
DEBUG: scanner is configured to use signature data from: 'suss'
ERROR: Found Java JAR file at lib/fcitx5/src/main/cpp/fcitx5/third_party/yoga/lib/jsr-305/jsr305.jar
ERROR: Found Android AAR library at lib/fcitx5/src/main/cpp/fcitx5/third_party/yoga/lib/soloader/soloader-0.5.1.aar
```